### PR TITLE
docs: update deploy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Then run the following commands:
 cd cdk
 npm ci
 npx cdk bootstrap
-npx cdk deploy
+npx cdk deploy --all
 ```
 
 Initial deployment usually takes about 20 minutes. You can also use `npx cdk deploy` command to deploy when you modified your CDK templates in the future.


### PR DESCRIPTION
The README states the deployment command as `npx cdk deploy`, but in reality, the `--all` option is required.

```console
$ npx cdk deploy      
Bundling asset ServerlessWebappStarterKitUsEast1Stack/SignPayloadHandler/Handler/Code/Stage...

  ...84148bb8321ddc842250d6cdb82d2fb89f14d4ac4130f7bd5b3a064d3-building/index.js  1.5kb

⚡ Done in 26ms
[WARNING] aws-cdk-lib.aws_ec2.InstanceProps#keyName is deprecated.
  - Use `keyPair` instead - https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2-readme.html#using-an-existing-ec2-key-pair
  This API will be removed in the next major release.
Since this app includes more than a single stack, specify which stacks to use (wildcards are supported) or specify `--all`
Stacks: ServerlessWebappStarterKitUsEast1Stack · ServerlessWebappStarterKitStack
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
