### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Build
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/aws-samples/serverless-full-stack-webapp-starter-kit/security/code-scanning/3](https://github.com/aws-samples/serverless-full-stack-webapp-starter-kit/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/build.yml`. This block can be placed at the top level (applies to all jobs) or at the job level (applies to individual jobs). Since neither job appears to require write access, the minimal required permission is `contents: read`. The best way to fix this is to add the following block after the workflow `name` and before the `on` key:

```yaml
permissions:
  contents: read
```

This ensures that the GITHUB_TOKEN used by all jobs in the workflow only has read access to repository contents, reducing the risk of privilege escalation or accidental modification of repository resources.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
