### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update_snapshot.yml
+++ b/.github/workflows/update_snapshot.yml
@@ -6,6 +6,8 @@ on:
     branches:
        - 'dependabot/**'
 
+permissions:
+  contents: write
 jobs:
   update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/aws-samples/serverless-full-stack-webapp-starter-kit/security/code-scanning/2](https://github.com/aws-samples/serverless-full-stack-webapp-starter-kit/security/code-scanning/2)

To fix the problem, you should add a `permissions` block to the workflow. Since the workflow commits changes to the repository (using EndBug/add-and-commit), it requires `contents: write` permission. If it also interacts with pull requests, you may need to add `pull-requests: write`, but based on the provided snippet, only repository contents are modified. The best way to fix this is to add a `permissions` block at the root level of the workflow file (above `jobs:`), specifying `contents: write`. This ensures that all jobs in the workflow have only the necessary permissions, reducing the risk of privilege escalation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
