### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,8 @@ on:
       - main
   workflow_dispatch:
   pull_request:
+permissions:
+  contents: read
 jobs:
   Build-and-Test-CDK:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/aws-samples/serverless-full-stack-webapp-starter-kit/security/code-scanning/1](https://github.com/aws-samples/serverless-full-stack-webapp-starter-kit/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow file, specifying the least privilege required for the jobs. Since the jobs only check out code and run build/test commands, they only need read access to repository contents. The best way to implement this is to add a `permissions` block at the root level of the workflow file (above `jobs:`), which will apply to all jobs unless overridden. This change should be made at the top of the `.github/workflows/build.yml` file, after the `name:` and `on:` blocks and before the `jobs:` block. No additional imports or definitions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
