### PR TITLE
feat: invalidate cloudfront caches when lambda configuration changes

### DIFF
--- a/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit-without-domain.test.ts.snap
+++ b/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit-without-domain.test.ts.snap
@@ -3193,6 +3193,96 @@ sudo service iptables save",
       "Type": "AWS::ECR::Repository",
       "UpdateReplacePolicy": "Delete",
     },
+    "WebappCloudFrontInvalidation588CF152": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "WebappCloudFrontInvalidationCustomResourcePolicy18C215D6",
+      ],
+      "Properties": Object {
+        "Create": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{"service":"cloudfront","action":"createInvalidation","parameters":{"DistributionId":"",
+              Object {
+                "Ref": "Webapp107041BD",
+              },
+              "","InvalidationBatch":{"CallerReference":"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "WebappHandlerCurrentVersionREDACTED",
+                  "Version",
+                ],
+              },
+              "","Paths":{"Quantity":1,"Items":["/*"]}}},"physicalResourceId":{"id":"invalidation"}}",
+            ],
+          ],
+        },
+        "InstallLatestAwsSdk": true,
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C",
+            "Arn",
+          ],
+        },
+        "Update": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{"service":"cloudfront","action":"createInvalidation","parameters":{"DistributionId":"",
+              Object {
+                "Ref": "Webapp107041BD",
+              },
+              "","InvalidationBatch":{"CallerReference":"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "WebappHandlerCurrentVersionREDACTED",
+                  "Version",
+                ],
+              },
+              "","Paths":{"Quantity":1,"Items":["/*"]}}},"physicalResourceId":{"id":"invalidation"}}",
+            ],
+          ],
+        },
+      },
+      "Type": "Custom::AWS",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "WebappCloudFrontInvalidationCustomResourcePolicy18C215D6": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "cloudfront:CreateInvalidation",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":cloudfront::123456789012:distribution/",
+                    Object {
+                      "Ref": "Webapp107041BD",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "WebappCloudFrontInvalidationCustomResourcePolicy18C215D6",
+        "Roles": Array [
+          Object {
+            "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "WebappHandler8DD158A3": Object {
       "DependsOn": Array [
         "VpcPrivateSubnet1DefaultRouteBE02A9ED",
@@ -3414,6 +3504,22 @@ sudo service iptables save",
         },
       },
       "Type": "AWS::Lambda::Function",
+    },
+    "WebappHandlerCurrentVersionREDACTED": Object {
+      "DependsOn": Array [
+        "VpcPrivateSubnet1DefaultRouteBE02A9ED",
+        "VpcPrivateSubnet1RouteTableAssociation70C59FA6",
+        "VpcPrivateSubnet2DefaultRoute060D2087",
+        "VpcPrivateSubnet2RouteTableAssociationA89CAD56",
+        "VpcPrivateSubnet3DefaultRoute94B74F0D",
+        "VpcPrivateSubnet3RouteTableAssociation16BDDC43",
+      ],
+      "Properties": Object {
+        "FunctionName": Object {
+          "Ref": "WebappHandler8DD158A3",
+        },
+      },
+      "Type": "AWS::Lambda::Version",
     },
     "WebappHandlerFunctionUrl7AEF8DEE": Object {
       "DependsOn": Array [

--- a/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit.test.ts.snap
+++ b/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit.test.ts.snap
@@ -3038,6 +3038,96 @@ sudo service iptables save",
       "Type": "AWS::ECR::Repository",
       "UpdateReplacePolicy": "Delete",
     },
+    "WebappCloudFrontInvalidation588CF152": Object {
+      "DeletionPolicy": "Delete",
+      "DependsOn": Array [
+        "WebappCloudFrontInvalidationCustomResourcePolicy18C215D6",
+      ],
+      "Properties": Object {
+        "Create": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{"service":"cloudfront","action":"createInvalidation","parameters":{"DistributionId":"",
+              Object {
+                "Ref": "Webapp107041BD",
+              },
+              "","InvalidationBatch":{"CallerReference":"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "WebappHandlerCurrentVersionREDACTED",
+                  "Version",
+                ],
+              },
+              "","Paths":{"Quantity":1,"Items":["/*"]}}},"physicalResourceId":{"id":"invalidation"}}",
+            ],
+          ],
+        },
+        "InstallLatestAwsSdk": true,
+        "ServiceToken": Object {
+          "Fn::GetAtt": Array [
+            "AWS679f53fac002430cb0da5b7982bd22872D164C4C",
+            "Arn",
+          ],
+        },
+        "Update": Object {
+          "Fn::Join": Array [
+            "",
+            Array [
+              "{"service":"cloudfront","action":"createInvalidation","parameters":{"DistributionId":"",
+              Object {
+                "Ref": "Webapp107041BD",
+              },
+              "","InvalidationBatch":{"CallerReference":"",
+              Object {
+                "Fn::GetAtt": Array [
+                  "WebappHandlerCurrentVersionREDACTED",
+                  "Version",
+                ],
+              },
+              "","Paths":{"Quantity":1,"Items":["/*"]}}},"physicalResourceId":{"id":"invalidation"}}",
+            ],
+          ],
+        },
+      },
+      "Type": "Custom::AWS",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "WebappCloudFrontInvalidationCustomResourcePolicy18C215D6": Object {
+      "Properties": Object {
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "cloudfront:CreateInvalidation",
+              "Effect": "Allow",
+              "Resource": Object {
+                "Fn::Join": Array [
+                  "",
+                  Array [
+                    "arn:",
+                    Object {
+                      "Ref": "AWS::Partition",
+                    },
+                    ":cloudfront::123456789012:distribution/",
+                    Object {
+                      "Ref": "Webapp107041BD",
+                    },
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "WebappCloudFrontInvalidationCustomResourcePolicy18C215D6",
+        "Roles": Array [
+          Object {
+            "Ref": "AWS679f53fac002430cb0da5b7982bd2287ServiceRoleC1EA0FF2",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
     "WebappHandler8DD158A3": Object {
       "DependsOn": Array [
         "VpcPrivateSubnet1DefaultRouteBE02A9ED",
@@ -3244,6 +3334,22 @@ sudo service iptables save",
         },
       },
       "Type": "AWS::Lambda::Function",
+    },
+    "WebappHandlerCurrentVersionREDACTED": Object {
+      "DependsOn": Array [
+        "VpcPrivateSubnet1DefaultRouteBE02A9ED",
+        "VpcPrivateSubnet1RouteTableAssociation70C59FA6",
+        "VpcPrivateSubnet2DefaultRoute060D2087",
+        "VpcPrivateSubnet2RouteTableAssociationA89CAD56",
+        "VpcPrivateSubnet3DefaultRoute94B74F0D",
+        "VpcPrivateSubnet3RouteTableAssociation16BDDC43",
+      ],
+      "Properties": Object {
+        "FunctionName": Object {
+          "Ref": "WebappHandler8DD158A3",
+        },
+      },
+      "Type": "AWS::Lambda::Version",
     },
     "WebappHandlerFunctionUrl7AEF8DEE": Object {
       "DependsOn": Array [


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

When next.js contains a static page, changes to the page will not be reflected due to cloudfront cache. This PR adds invalidation of old cache when Lambda configuration changes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
