### PR TITLE
Change Next.js middleware runtime to nodejs

### DIFF
--- a/webapp/src/middleware.ts
+++ b/webapp/src/middleware.ts
@@ -27,6 +27,7 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
+  runtime: 'nodejs',
   matcher: [
     /*
      * Match all request paths except for the ones starting with:


### PR DESCRIPTION
## Overview
Changed Next.js middleware runtime from the default Edge runtime to Node.js runtime.

## Changes
- Added `runtime: 'nodejs'` to the config object in `webapp/src/middleware.ts`

## Rationale
- Leverages the Node.js runtime feature supported in Next.js v15.5 and later
- Enables access to richer Node.js APIs

## Testing
- Verified compatibility with Next.js v15.5.2

## References
- [Next.js Middleware Runtime Documentation](https://nextjs.org/docs/app/api-reference/file-conventions/middleware#runtime)