### PR TITLE
fix: pass useNatInstance prop to MainStack

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -46,6 +46,7 @@ new MainStack(app, 'ServerlessWebappStarterKitStack', {
   crossRegionReferences: true,
   sharedCertificate: virginia.certificate,
   domainName: props.domainName,
+  useNatInstance: props.useNatInstance,
   signPayloadHandler: virginia.signPayloadHandler,
 });
 


### PR DESCRIPTION
## Problem

The `useNatInstance` property was declared in `EnvironmentProps` and set in the `props` object, but it was not being passed to the `MainStack` constructor.

## Solution

Added `useNatInstance: props.useNatInstance` to the `MainStack` constructor call.

## Changes

- Modified `cdk/bin/cdk.ts` to pass the `useNatInstance` prop to `MainStack`

This ensures that the `useNatInstance` configuration is properly propagated to the main stack, allowing users to control whether to use NAT instances or NAT gateways.

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:1765070357823049 -->