### PR TITLE
Change port forwarding local port to 5433 and add operational commands documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ ServerlessWebappStarterKitStack.FrontendDomainName = https://web.exmaple.com
 
 Opening the URL in `FrontendDomainName` output, you can now try the sample app on your browser.
 
+> **Note:** The deployment also outputs operational commands for database management. `DatabasePortForwardCommand` establishes a local connection to your RDS database on port 5433, and `DatabaseSecretsCommand` retrieves database credentials from AWS Secrets Manager.
+
 ### WebApp Deployment
 
 The Next.js webapp is built and deployed during the CDK deployment process using [deploy-time-build](https://github.com/tmokmss/deploy-time-build). This approach ensures your application is containerized and deployed to AWS Lambda as part of the infrastructure deployment. See the [implementation](./cdk/lib/constructs/webapp.ts) for details.

--- a/cdk/lib/constructs/database.ts
+++ b/cdk/lib/constructs/database.ts
@@ -67,7 +67,7 @@ export class Database extends Construct implements ec2.IConnectable {
         host.instanceId
       } --document-name AWS-StartPortForwardingSessionToRemoteHost --parameters '{"portNumber":["${
         cluster.clusterEndpoint.port
-      }"], "localPortNumber":["${cluster.clusterEndpoint.port}"], "host": ["${cluster.clusterEndpoint.hostname}"]}'`,
+      }"], "localPortNumber":["5433"], "host": ["${cluster.clusterEndpoint.hostname}"]}'`,
     });
     new CfnOutput(this, 'DatabaseSecretsCommand', {
       value: `aws secretsmanager get-secret-value --secret-id ${cluster.secret!.secretName} --region ${

--- a/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit-without-domain.test.ts.snap
+++ b/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit-without-domain.test.ts.snap
@@ -338,14 +338,7 @@ exports[`Snapshot test 2`] = `
                 "Endpoint.Port",
               ],
             },
-            ""], "localPortNumber":["",
-            {
-              "Fn::GetAtt": [
-                "DatabaseCluster5B53A178",
-                "Endpoint.Port",
-              ],
-            },
-            ""], "host": ["",
+            ""], "localPortNumber":["5433"], "host": ["",
             {
               "Fn::GetAtt": [
                 "DatabaseCluster5B53A178",

--- a/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit.test.ts.snap
+++ b/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit.test.ts.snap
@@ -372,14 +372,7 @@ exports[`Snapshot test 2`] = `
                 "Endpoint.Port",
               ],
             },
-            ""], "localPortNumber":["",
-            {
-              "Fn::GetAtt": [
-                "DatabaseCluster5B53A178",
-                "Endpoint.Port",
-              ],
-            },
-            ""], "host": ["",
+            ""], "localPortNumber":["5433"], "host": ["",
             {
               "Fn::GetAtt": [
                 "DatabaseCluster5B53A178",


### PR DESCRIPTION
## Summary

This PR updates the port forwarding configuration and adds documentation for operational commands output by CDK deployment.

## Changes

1. **Port forwarding local port**: Changed from 5432 to 5433
   - Avoids conflicts with local Docker Compose PostgreSQL instances
   - Prevents accidental pushing of local changes to remote database

2. **Documentation**: Added a note in README.md describing the operational commands
   - Explains `DatabasePortForwardCommand` usage for local database connections
   - Mentions `DatabaseSecretsCommand` for retrieving credentials from AWS Secrets Manager

3. **CDK snapshot tests**: Updated snapshots to reflect the port change

## Testing

- CDK snapshot tests updated and passing
- All changes verified locally

<!-- DO NOT EDIT: System generated metadata -->
<!-- WORKER_ID:1765360432079249 -->