### PR TITLE
fix: support Amazon Linux 2023 for NAT instance

### DIFF
--- a/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit-without-domain.test.ts.snap
+++ b/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit-without-domain.test.ts.snap
@@ -2712,14 +2712,15 @@ exports.handler = async function (event, context) {
         ],
         "UserData": {
           "Fn::Base64": "#!/bin/bash
-yum install iptables-services -y
+for i in {1..5}; do yum install iptables-services -y && break || sleep 10; done
 systemctl enable iptables
 systemctl start iptables
 echo "net.ipv4.ip_forward=1" > /etc/sysctl.d/custom-ip-forwarding.conf
-sudo sysctl -p /etc/sysctl.d/custom-ip-forwarding.conf
-sudo /sbin/iptables -t nat -A POSTROUTING -o $(route | awk '/^default/{print $NF}') -j MASQUERADE
-sudo /sbin/iptables -F FORWARD
-sudo service iptables save",
+sysctl -p /etc/sysctl.d/custom-ip-forwarding.conf
+IFACE=$(ip route show default | awk '{print $5}')
+/sbin/iptables -t nat -A POSTROUTING -o $IFACE -j MASQUERADE
+/sbin/iptables -F FORWARD
+service iptables save",
         },
       },
       "Type": "AWS::EC2::Instance",

--- a/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit.test.ts.snap
+++ b/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit.test.ts.snap
@@ -2544,14 +2544,15 @@ exports[`Snapshot test 2`] = `
         ],
         "UserData": {
           "Fn::Base64": "#!/bin/bash
-yum install iptables-services -y
+for i in {1..5}; do yum install iptables-services -y && break || sleep 10; done
 systemctl enable iptables
 systemctl start iptables
 echo "net.ipv4.ip_forward=1" > /etc/sysctl.d/custom-ip-forwarding.conf
-sudo sysctl -p /etc/sysctl.d/custom-ip-forwarding.conf
-sudo /sbin/iptables -t nat -A POSTROUTING -o $(route | awk '/^default/{print $NF}') -j MASQUERADE
-sudo /sbin/iptables -F FORWARD
-sudo service iptables save",
+sysctl -p /etc/sysctl.d/custom-ip-forwarding.conf
+IFACE=$(ip route show default | awk '{print $5}')
+/sbin/iptables -t nat -A POSTROUTING -o $IFACE -j MASQUERADE
+/sbin/iptables -F FORWARD
+service iptables save",
         },
       },
       "Type": "AWS::EC2::Instance",


### PR DESCRIPTION
## Summary

CDK's `NatInstanceProviderV2` uses the `route` command in its default user data, which requires the `net-tools` package. However, Amazon Linux 2023 (the default AMI for `NatInstanceProviderV2`) doesn't have `net-tools` pre-installed, causing NAT instances to fail silently.

## Problem

The default user data in CDK contains:
```bash
sudo /sbin/iptables -t nat -A POSTROUTING -o $(route | awk '/^default/{print $NF}') -j MASQUERADE
```

This fails on AL2023 because the `route` command is not available.

## Solution

This change provides custom user data that uses `ip route` instead of `route` to determine the default network interface:
```bash
IFACE=$(ip route show default | awk '{print $5}')
/sbin/iptables -t nat -A POSTROUTING -o $IFACE -j MASQUERADE
```

## Reference

- CDK source code: https://github.com/aws/aws-cdk/blob/main/packages/aws-cdk-lib/aws-ec2/lib/nat.ts

## Testing

- Deployed the stack with the fix and verified NAT instance works correctly
- Application accessible via CloudFront (returns 307 redirect to sign-in page as expected)