### PR TITLE
fix: add lambda:InvokeFunction permission for CloudFront OAC

### DIFF
--- a/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit-without-domain.test.ts.snap
+++ b/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit-without-domain.test.ts.snap
@@ -3684,6 +3684,38 @@ sudo service iptables save",
       },
       "Type": "AWS::IAM::Policy",
     },
+    "WebappInvokeFunctionPermission8F3F2610": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "WebappHandler8DD158A3",
+            "Arn",
+          ],
+        },
+        "Principal": "cloudfront.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":cloudfront::",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":distribution/",
+              {
+                "Ref": "Webapp107041BD",
+              },
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
     "WebappMigrationRunnerAC67C012": {
       "DependsOn": [
         "VpcPrivateSubnet1DefaultRouteBE02A9ED",

--- a/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit.test.ts.snap
+++ b/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit.test.ts.snap
@@ -3490,6 +3490,38 @@ sudo service iptables save",
       },
       "Type": "AWS::IAM::Policy",
     },
+    "WebappInvokeFunctionPermission8F3F2610": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "WebappHandler8DD158A3",
+            "Arn",
+          ],
+        },
+        "Principal": "cloudfront.amazonaws.com",
+        "SourceArn": {
+          "Fn::Join": [
+            "",
+            [
+              "arn:",
+              {
+                "Ref": "AWS::Partition",
+              },
+              ":cloudfront::",
+              {
+                "Ref": "AWS::AccountId",
+              },
+              ":distribution/",
+              {
+                "Ref": "Webapp107041BD",
+              },
+            ],
+          ],
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
     "WebappMigrationRunnerAC67C012": {
       "DependsOn": [
         "VpcPrivateSubnet1DefaultRouteBE02A9ED",


### PR DESCRIPTION
## Summary

Starting October 2025, new Lambda function URLs require both `lambda:InvokeFunctionUrl` and `lambda:InvokeFunction` permissions when using CloudFront Origin Access Control (OAC).

## Problem

CDK's `FunctionUrlOrigin.withOriginAccessControl` only adds `lambda:InvokeFunctionUrl` permission. New deployments after October 2025 would fail with 403 errors because the `lambda:InvokeFunction` permission is missing.

## Solution

Explicitly add `lambda:InvokeFunction` permission using `CfnPermission`:

```typescript
new CfnPermission(this, 'InvokeFunctionPermission', {
  action: 'lambda:InvokeFunction',
  functionName: handler.functionArn,
  principal: 'cloudfront.amazonaws.com',
  sourceArn: `arn:${Aws.PARTITION}:cloudfront::${Aws.ACCOUNT_ID}:distribution/${distribution.distributionId}`,
});
```

## Reference

- AWS Documentation: https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html

> Starting in October 2025, new function URLs will require both `lambda:InvokeFunctionUrl` and `lambda:InvokeFunction` permissions.

## Note

- Existing function URLs created before October 2025 are not affected by this change.
- **Please merge #81 (NAT Instance AL2023 fix) first.** This PR depends on that fix for proper testing, as the NAT Instance is required for Lambda to access external services.