### PR TITLE
chore(cdk): add Application tag to all stacks

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -52,7 +52,7 @@ new MainStack(app, 'ServerlessWebappStarterKitStack', {
   signPayloadHandler: virginia.signPayloadHandler,
 });
 
-cdk.Tags.of(app).add('Application', 'ServerlessWebappStarterKit');
+cdk.Tags.of(app).add('Application', 'ServerlessFullStackWebappStarterKit');
 
 // import { Aspects } from 'aws-cdk-lib';
 // import { AwsSolutionsChecks } from 'cdk-nag';


### PR DESCRIPTION
## Summary
- Add `Application: ServerlessWebappStarterKit` tag to the entire CDK app
- Uses `cdk.Tags.of(app).add()` to automatically propagate the tag to all resources across both stacks