### PR TITLE
feat: increase webapp Lambda memory from 512MB to 1024MB

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ The following table provides a sample cost breakdown for deploying this system i
 | Aurora Serverless v2 | 0.5 ACU × 2 hour/day, 1GB storage | 3.6 |
 | Cognito | 100 MAU (Monthly Active Users) | 1.5 |
 | AppSync Events | 100 events/month, 10 hours connection/user/month | 0.02 |
-| Lambda | 512MB×200ms/request | 0.15 |
+| Lambda | 1024MB×200ms/request | 0.15 |
 | Lambda@Edge | 128MB×50ms/request | 0.09 |
 | VPC | NAT Instance (t4g.nano) x1 | 3.02 |
 | EventBridge | Scheduler 100 jobs/month | 0.0001 |

--- a/cdk/lib/constructs/webapp.ts
+++ b/cdk/lib/constructs/webapp.ts
@@ -82,7 +82,7 @@ export class Webapp extends Construct {
         ASYNC_JOB_HANDLER_ARN: asyncJob.handler.functionArn,
       },
       vpc: database.cluster.vpc,
-      memorySize: 512,
+      memorySize: 1024,
       architecture: Architecture.ARM_64,
     });
     handler.connections.allowToDefaultPort(database);

--- a/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit-without-domain.test.ts.snap
+++ b/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit-without-domain.test.ts.snap
@@ -3466,7 +3466,7 @@ service iptables save",
             },
           },
         },
-        "MemorySize": 512,
+        "MemorySize": 1024,
         "PackageType": "Image",
         "Role": {
           "Fn::GetAtt": [

--- a/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit.test.ts.snap
+++ b/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit.test.ts.snap
@@ -3296,7 +3296,7 @@ service iptables save",
             },
           },
         },
-        "MemorySize": 512,
+        "MemorySize": 1024,
         "PackageType": "Image",
         "Role": {
           "Fn::GetAtt": [


### PR DESCRIPTION
## Summary

Increase the webapp Lambda function memory from 512MB to 1024MB to improve cold start performance.

## Problem

With 512MB (0.29 vCPU), Next.js cold starts take over 20 seconds due to CPU-bound operations (JS bundle parsing, DNS resolution, TLS handshake).

## Measurement Results

| Memory | vCPU | Cold Start P50 | Monthly Cost | vs 512MB |
|--------|------|----------------|-------------|----------|
| 512MB | 0.29 | 21.7s | $0.074 | — |
| **1024MB** | **0.58** | **7.1s** | **$0.051** | **-32%** |
| 1536MB | 0.87 | 5.6s | $0.060 | -19% |
| 3008MB | 1.7 | 4.0s | $0.084 | +14% |

1024MB is the sweet spot: 3x faster cold starts and 32% cost reduction due to lower billed duration.

## Changes

- `cdk/lib/constructs/webapp.ts`: memorySize 512 → 1024
- CDK test snapshots updated
- README cost table updated

Closes #101