### PR TITLE
feat: add CloudWatch LogGroup with retention policy to Lambda functions

### DIFF
--- a/cdk/lib/constructs/async-job.ts
+++ b/cdk/lib/constructs/async-job.ts
@@ -1,5 +1,6 @@
 import { Construct } from 'constructs';
-import { CfnOutput, Duration, TimeZone } from 'aws-cdk-lib';
+import { CfnOutput, Duration, RemovalPolicy, TimeZone } from 'aws-cdk-lib';
+import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Architecture, DockerImageCode, DockerImageFunction, IFunction } from 'aws-cdk-lib/aws-lambda';
 import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import { Database } from './database';
@@ -37,6 +38,10 @@ export class AsyncJob extends Construct {
       vpc: database.cluster.vpc,
       // limit concurrency to mitigate any possible EDoS attacks
       reservedConcurrentExecutions: 1,
+      logGroup: new LogGroup(this, 'HandlerLogs', {
+        retention: RetentionDays.ONE_WEEK,
+        removalPolicy: RemovalPolicy.DESTROY,
+      }),
     });
 
     handler.connections.allowToDefaultPort(database);

--- a/cdk/lib/constructs/webapp.ts
+++ b/cdk/lib/constructs/webapp.ts
@@ -1,4 +1,5 @@
-import { IgnoreMode, Duration, CfnOutput, Stack } from 'aws-cdk-lib';
+import { IgnoreMode, Duration, CfnOutput, Stack, RemovalPolicy } from 'aws-cdk-lib';
+import { LogGroup, RetentionDays } from 'aws-cdk-lib/aws-logs';
 import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import { DockerImageFunction, DockerImageCode, Architecture } from 'aws-cdk-lib/aws-lambda';
 import { Construct } from 'constructs';
@@ -84,6 +85,10 @@ export class Webapp extends Construct {
       vpc: database.cluster.vpc,
       memorySize: 1024,
       architecture: Architecture.ARM_64,
+      logGroup: new LogGroup(this, 'HandlerLogs', {
+        retention: RetentionDays.ONE_WEEK,
+        removalPolicy: RemovalPolicy.DESTROY,
+      }),
     });
     handler.connections.allowToDefaultPort(database);
     asyncJob.handler.grantInvoke(handler);
@@ -154,6 +159,10 @@ export class Webapp extends Construct {
       },
       vpc: database.cluster.vpc,
       memorySize: 256,
+      logGroup: new LogGroup(this, 'MigrationRunnerLogs', {
+        retention: RetentionDays.ONE_WEEK,
+        removalPolicy: RemovalPolicy.DESTROY,
+      }),
     });
     migrationRunner.connections.allowToDefaultPort(database);
 

--- a/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit-without-domain.test.ts.snap
+++ b/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit-without-domain.test.ts.snap
@@ -809,6 +809,11 @@ exports[`Snapshot test 2`] = `
             "async-job-runner.handler",
           ],
         },
+        "LoggingConfig": {
+          "LogGroup": {
+            "Ref": "AsyncJobHandlerLogs20DFEE3E",
+          },
+        },
         "MemorySize": 256,
         "PackageType": "Image",
         "ReservedConcurrentExecutions": 1,
@@ -842,6 +847,14 @@ exports[`Snapshot test 2`] = `
         },
       },
       "Type": "AWS::Lambda::Function",
+    },
+    "AsyncJobHandlerLogs20DFEE3E": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "RetentionInDays": 7,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Delete",
     },
     "AsyncJobHandlerSecurityGroupF59812E6": {
       "DependsOn": [
@@ -3466,6 +3479,11 @@ service iptables save",
             },
           },
         },
+        "LoggingConfig": {
+          "LogGroup": {
+            "Ref": "WebappHandlerLogs87A6D2D7",
+          },
+        },
         "MemorySize": 1024,
         "PackageType": "Image",
         "Role": {
@@ -3535,6 +3553,14 @@ service iptables save",
         },
       },
       "Type": "AWS::Lambda::Url",
+    },
+    "WebappHandlerLogs87A6D2D7": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "RetentionInDays": 7,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Delete",
     },
     "WebappHandlerSecurityGroup5451B519": {
       "DependsOn": [
@@ -3829,6 +3855,11 @@ service iptables save",
             "migration-runner.handler",
           ],
         },
+        "LoggingConfig": {
+          "LogGroup": {
+            "Ref": "WebappMigrationRunnerLogsD9A84B90",
+          },
+        },
         "MemorySize": 256,
         "PackageType": "Image",
         "Role": {
@@ -3877,6 +3908,14 @@ service iptables save",
         },
       },
       "Type": "AWS::Lambda::Version",
+    },
+    "WebappMigrationRunnerLogsD9A84B90": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "RetentionInDays": 7,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Delete",
     },
     "WebappMigrationRunnerSecurityGroup7F0DF264": {
       "DependsOn": [

--- a/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit.test.ts.snap
+++ b/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit.test.ts.snap
@@ -830,6 +830,11 @@ exports[`Snapshot test 2`] = `
             "async-job-runner.handler",
           ],
         },
+        "LoggingConfig": {
+          "LogGroup": {
+            "Ref": "AsyncJobHandlerLogs20DFEE3E",
+          },
+        },
         "MemorySize": 256,
         "PackageType": "Image",
         "ReservedConcurrentExecutions": 1,
@@ -863,6 +868,14 @@ exports[`Snapshot test 2`] = `
         },
       },
       "Type": "AWS::Lambda::Function",
+    },
+    "AsyncJobHandlerLogs20DFEE3E": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "RetentionInDays": 7,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Delete",
     },
     "AsyncJobHandlerSecurityGroupF59812E6": {
       "DependsOn": [
@@ -3296,6 +3309,11 @@ service iptables save",
             },
           },
         },
+        "LoggingConfig": {
+          "LogGroup": {
+            "Ref": "WebappHandlerLogs87A6D2D7",
+          },
+        },
         "MemorySize": 1024,
         "PackageType": "Image",
         "Role": {
@@ -3365,6 +3383,14 @@ service iptables save",
         },
       },
       "Type": "AWS::Lambda::Url",
+    },
+    "WebappHandlerLogs87A6D2D7": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "RetentionInDays": 7,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Delete",
     },
     "WebappHandlerSecurityGroup5451B519": {
       "DependsOn": [
@@ -3635,6 +3661,11 @@ service iptables save",
             "migration-runner.handler",
           ],
         },
+        "LoggingConfig": {
+          "LogGroup": {
+            "Ref": "WebappMigrationRunnerLogsD9A84B90",
+          },
+        },
         "MemorySize": 256,
         "PackageType": "Image",
         "Role": {
@@ -3683,6 +3714,14 @@ service iptables save",
         },
       },
       "Type": "AWS::Lambda::Version",
+    },
+    "WebappMigrationRunnerLogsD9A84B90": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "RetentionInDays": 7,
+      },
+      "Type": "AWS::Logs::LogGroup",
+      "UpdateReplacePolicy": "Delete",
     },
     "WebappMigrationRunnerSecurityGroup7F0DF264": {
       "DependsOn": [


### PR DESCRIPTION
## Summary

Add explicit CDK-managed CloudWatch LogGroups with 1-week retention to all Lambda functions to prevent unbounded log storage costs.

## Problem

Without explicit LogGroup configuration, Lambda auto-creates LogGroups with infinite retention. As logs accumulate, storage costs grow without bound.

## Changes

Added `LogGroup` with `RetentionDays.ONE_WEEK` and `RemovalPolicy.DESTROY` to:

| Construct | Lambda | File |
|-----------|--------|------|
| Webapp | Handler | `cdk/lib/constructs/webapp.ts` |
| Webapp | MigrationRunner | `cdk/lib/constructs/webapp.ts` |
| AsyncJob | Handler | `cdk/lib/constructs/async-job.ts` |

CDK test snapshots updated accordingly.

## Out of scope

Lambda@Edge (SignPayload) is excluded — edge-region LogGroups cannot be managed by CDK and will become unnecessary after #66.

Closes #103