### PR TITLE
fix: prevent CloudFront cache poisoning for Next.js RSC responses

### DIFF
--- a/cdk/.gitignore
+++ b/cdk/.gitignore
@@ -1,5 +1,6 @@
 *.js
 !jest.config.js
+!lib/constructs/cf-lambda-furl-service/cf-function/*.js
 *.d.ts
 node_modules
 

--- a/cdk/lib/constructs/cf-lambda-furl-service/cf-function/cache-key.js
+++ b/cdk/lib/constructs/cf-lambda-furl-service/cf-function/cache-key.js
@@ -1,0 +1,39 @@
+// CloudFront Functions JS 2.0
+// Combines Next.js RSC-related headers into a single hashed cache key header
+// to prevent cache poisoning between HTML and RSC flight responses.
+//
+// Next.js App Router sets Vary: rsc, next-router-state-tree, next-router-prefetch,
+// next-router-segment-prefetch (and next-url for interception routes).
+// CloudFront ignores Vary and requires explicit cache key configuration,
+// but its Cache Policy has a 10-header limit. This function hashes all
+// RSC headers into one header to stay within the limit.
+async function handler(event) {
+  var h = event.request.headers;
+  var parts = [
+    'rsc',
+    'next-router-prefetch',
+    'next-router-state-tree',
+    'next-router-segment-prefetch',
+    'next-url',
+  ];
+  var key = '';
+  for (var i = 0; i < parts.length; i++) {
+    if (h[parts[i]]) {
+      key += parts[i] + '=' + h[parts[i]].value + ';';
+    }
+  }
+  if (key) {
+    // FNV-1a hash (32-bit). Cryptographic strength is unnecessary;
+    // we only need distinct cache keys for distinct header combinations.
+    // See: https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+    var FNV_OFFSET_BASIS = 2166136261;
+    var FNV_PRIME = 16777619;
+    var hash = FNV_OFFSET_BASIS;
+    for (var j = 0; j < key.length; j++) {
+      hash ^= key.charCodeAt(j);
+      hash = (hash * FNV_PRIME) | 0;
+    }
+    event.request.headers['x-nextjs-cache-key'] = { value: String(hash >>> 0) };
+  }
+  return event.request;
+}

--- a/cdk/lib/constructs/cf-lambda-furl-service/service.ts
+++ b/cdk/lib/constructs/cf-lambda-furl-service/service.ts
@@ -8,11 +8,16 @@ import {
   CachePolicy,
   CacheQueryStringBehavior,
   Distribution,
+  Function as CfFunction,
+  FunctionCode as CfFunctionCode,
+  FunctionEventType,
+  FunctionRuntime,
   LambdaEdgeEventType,
   OriginRequestPolicy,
   SecurityPolicyProtocol,
 } from 'aws-cdk-lib/aws-cloudfront';
 import { FunctionUrlOrigin } from 'aws-cdk-lib/aws-cloudfront-origins';
+import * as path from 'path';
 import { StringParameter } from 'aws-cdk-lib/aws-ssm';
 import { ARecord, IHostedZone, RecordTarget } from 'aws-cdk-lib/aws-route53';
 import { CloudFrontTarget } from 'aws-cdk-lib/aws-route53-targets';
@@ -89,11 +94,22 @@ export class CloudFrontLambdaFunctionUrlService extends Construct {
         'X-HTTP-Method-Override',
         'X-HTTP-Method',
         'X-Method-Override',
+        // Hashed Next.js RSC headers set by the CloudFront Function below.
+        // See cf-function/cache-key.js for details.
+        'x-nextjs-cache-key',
       ),
       defaultTtl: Duration.seconds(0),
       cookieBehavior: CacheCookieBehavior.all(),
       enableAcceptEncodingBrotli: true,
       enableAcceptEncodingGzip: true,
+    });
+
+    // CloudFront Function to hash Next.js RSC headers into a single cache key header.
+    // This prevents cache poisoning between HTML and RSC flight responses while
+    // staying within CloudFront's 10-header limit on Cache Policies.
+    const cacheKeyFunction = new CfFunction(this, 'CacheKeyFunction', {
+      runtime: FunctionRuntime.JS_2_0,
+      code: CfFunctionCode.fromFile({ filePath: path.join(__dirname, 'cf-function', 'cache-key.js') }),
     });
 
     const distribution = new Distribution(this, 'Resource', {
@@ -103,6 +119,12 @@ export class CloudFrontLambdaFunctionUrlService extends Construct {
         cachePolicy,
         allowedMethods: AllowedMethods.ALLOW_ALL,
         originRequestPolicy: OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+        functionAssociations: [
+          {
+            function: cacheKeyFunction,
+            eventType: FunctionEventType.VIEWER_REQUEST,
+          },
+        ],
         edgeLambdas: [
           {
             functionVersion: signPayloadHandler.versionArn(this),

--- a/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit-without-domain.test.ts.snap
+++ b/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit-without-domain.test.ts.snap
@@ -2980,6 +2980,17 @@ service iptables save",
               "Ref": "WebappSharedCachePolicy14FEE4A0",
             },
             "Compress": true,
+            "FunctionAssociations": [
+              {
+                "EventType": "viewer-request",
+                "FunctionARN": {
+                  "Fn::GetAtt": [
+                    "WebappCacheKeyFunction6C227CE2",
+                    "FunctionARN",
+                  ],
+                },
+              },
+            ],
             "LambdaFunctionAssociations": [
               {
                 "EventType": "origin-request",
@@ -3199,6 +3210,57 @@ service iptables save",
       },
       "Type": "AWS::ECR::Repository",
       "UpdateReplacePolicy": "Delete",
+    },
+    "WebappCacheKeyFunction6C227CE2": {
+      "Properties": {
+        "AutoPublish": true,
+        "FunctionCode": "// CloudFront Functions JS 2.0
+// Combines Next.js RSC-related headers into a single hashed cache key header
+// to prevent cache poisoning between HTML and RSC flight responses.
+//
+// Next.js App Router sets Vary: rsc, next-router-state-tree, next-router-prefetch,
+// next-router-segment-prefetch (and next-url for interception routes).
+// CloudFront ignores Vary and requires explicit cache key configuration,
+// but its Cache Policy has a 10-header limit. This function hashes all
+// RSC headers into one header to stay within the limit.
+async function handler(event) {
+  var h = event.request.headers;
+  var parts = [
+    'rsc',
+    'next-router-prefetch',
+    'next-router-state-tree',
+    'next-router-segment-prefetch',
+    'next-url',
+  ];
+  var key = '';
+  for (var i = 0; i < parts.length; i++) {
+    if (h[parts[i]]) {
+      key += parts[i] + '=' + h[parts[i]].value + ';';
+    }
+  }
+  if (key) {
+    // FNV-1a hash (32-bit). Cryptographic strength is unnecessary;
+    // we only need distinct cache keys for distinct header combinations.
+    // See: https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+    var FNV_OFFSET_BASIS = 2166136261;
+    var FNV_PRIME = 16777619;
+    var hash = FNV_OFFSET_BASIS;
+    for (var j = 0; j < key.length; j++) {
+      hash ^= key.charCodeAt(j);
+      hash = (hash * FNV_PRIME) | 0;
+    }
+    event.request.headers['x-nextjs-cache-key'] = { value: String(hash >>> 0) };
+  }
+  return event.request;
+}
+",
+        "FunctionConfig": {
+          "Comment": "us-west-2ServerlessWebappCacheKeyFunction86D1ABE9",
+          "Runtime": "cloudfront-js-2.0",
+        },
+        "Name": "us-west-2ServerlessWebappCacheKeyFunction86D1ABE9",
+      },
+      "Type": "AWS::CloudFront::Function",
     },
     "WebappCloudFrontInvalidation588CF152": {
       "DeletionPolicy": "Delete",
@@ -4094,6 +4156,7 @@ service iptables save",
                 "X-HTTP-Method-Override",
                 "X-HTTP-Method",
                 "X-Method-Override",
+                "x-nextjs-cache-key",
               ],
             },
             "QueryStringsConfig": {

--- a/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit.test.ts.snap
+++ b/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit.test.ts.snap
@@ -2815,6 +2815,17 @@ service iptables save",
               "Ref": "WebappSharedCachePolicy14FEE4A0",
             },
             "Compress": true,
+            "FunctionAssociations": [
+              {
+                "EventType": "viewer-request",
+                "FunctionARN": {
+                  "Fn::GetAtt": [
+                    "WebappCacheKeyFunction6C227CE2",
+                    "FunctionARN",
+                  ],
+                },
+              },
+            ],
             "LambdaFunctionAssociations": [
               {
                 "EventType": "origin-request",
@@ -3044,6 +3055,57 @@ service iptables save",
       },
       "Type": "AWS::ECR::Repository",
       "UpdateReplacePolicy": "Delete",
+    },
+    "WebappCacheKeyFunction6C227CE2": {
+      "Properties": {
+        "AutoPublish": true,
+        "FunctionCode": "// CloudFront Functions JS 2.0
+// Combines Next.js RSC-related headers into a single hashed cache key header
+// to prevent cache poisoning between HTML and RSC flight responses.
+//
+// Next.js App Router sets Vary: rsc, next-router-state-tree, next-router-prefetch,
+// next-router-segment-prefetch (and next-url for interception routes).
+// CloudFront ignores Vary and requires explicit cache key configuration,
+// but its Cache Policy has a 10-header limit. This function hashes all
+// RSC headers into one header to stay within the limit.
+async function handler(event) {
+  var h = event.request.headers;
+  var parts = [
+    'rsc',
+    'next-router-prefetch',
+    'next-router-state-tree',
+    'next-router-segment-prefetch',
+    'next-url',
+  ];
+  var key = '';
+  for (var i = 0; i < parts.length; i++) {
+    if (h[parts[i]]) {
+      key += parts[i] + '=' + h[parts[i]].value + ';';
+    }
+  }
+  if (key) {
+    // FNV-1a hash (32-bit). Cryptographic strength is unnecessary;
+    // we only need distinct cache keys for distinct header combinations.
+    // See: https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+    var FNV_OFFSET_BASIS = 2166136261;
+    var FNV_PRIME = 16777619;
+    var hash = FNV_OFFSET_BASIS;
+    for (var j = 0; j < key.length; j++) {
+      hash ^= key.charCodeAt(j);
+      hash = (hash * FNV_PRIME) | 0;
+    }
+    event.request.headers['x-nextjs-cache-key'] = { value: String(hash >>> 0) };
+  }
+  return event.request;
+}
+",
+        "FunctionConfig": {
+          "Comment": "us-west-2ServerlessWebappCacheKeyFunction86D1ABE9",
+          "Runtime": "cloudfront-js-2.0",
+        },
+        "Name": "us-west-2ServerlessWebappCacheKeyFunction86D1ABE9",
+      },
+      "Type": "AWS::CloudFront::Function",
     },
     "WebappCloudFrontInvalidation588CF152": {
       "DeletionPolicy": "Delete",
@@ -3918,6 +3980,7 @@ service iptables save",
                 "X-HTTP-Method-Override",
                 "X-HTTP-Method",
                 "X-Method-Override",
+                "x-nextjs-cache-key",
               ],
             },
             "QueryStringsConfig": {


### PR DESCRIPTION
## Summary

Prevent CloudFront cache poisoning between HTML and RSC flight responses by adding a CloudFront Function that hashes Next.js RSC headers into a single cache key header.

Closes #100
Supersedes #118

## Problem

Next.js App Router sends two types of requests to the same URL:
1. **HTML requests** — full page loads
2. **RSC requests** — client-side navigation with `RSC: 1` header, returning `text/x-component` flight data

Next.js sets `Vary: rsc, next-router-state-tree, next-router-prefetch, next-router-segment-prefetch` (plus `next-url` for interception routes) to signal that responses differ based on these headers. However, CloudFront does not honor `Vary` — headers must be explicitly included in the Cache Policy to become part of the cache key.

Without this fix, when CloudFront caching is active (static pages, ISR, or explicit cache headers), an RSC response can be cached and served for a normal HTML request, or vice versa.

## Approach

Adding all 5 RSC headers directly to the Cache Policy would hit CloudFront's **10-header limit** (5 existing + 5 = 10, no room for future additions). Instead, we use a **CloudFront Function** (VIEWER_REQUEST) that:

1. Reads the 5 Next.js RSC headers (`rsc`, `next-router-prefetch`, `next-router-state-tree`, `next-router-segment-prefetch`, `next-url`)
2. Hashes them into a single `x-nextjs-cache-key` header using FNV-1a
3. The Cache Policy includes only `x-nextjs-cache-key` (6/10 headers used)

This is the same approach used by [cdk-nextjs](https://github.com/jetbridge/cdk-nextjs) (which hashes into `x-open-next-cache-key`).

### Why CloudFront Function (not Lambda@Edge)?

The existing `sign-payload` Lambda@Edge (ORIGIN_REQUEST) handles request body hashing for SigV4, which requires body access — only possible with Lambda@Edge. The RSC header hashing is a lightweight header-only operation ideal for CloudFront Functions. Both coexist on the same behavior (CF Function at VIEWER_REQUEST, L@E at ORIGIN_REQUEST).

## Files changed

- `cdk/lib/constructs/cf-lambda-furl-service/cf-function/cache-key.js` — New CloudFront Function
- `cdk/lib/constructs/cf-lambda-furl-service/service.ts` — Wire up CF Function + add `x-nextjs-cache-key` to Cache Policy

## Grounding / References

- **Next.js source (v16.1.6)** `base-server.js:setVaryHeader()` — Confirms `Vary` includes `rsc`, `next-router-state-tree`, `next-router-prefetch`, `next-router-segment-prefetch` for all App Router pages, plus `next-url` for interception routes
- **Next.js source** `app-render.js:149` — `next-router-segment-prefetch: /_tree` triggers a different response (route tree only), confirming it must be in the cache key
- **CVE-2025-49005** ([Vercel](https://vercel.com/changelog/cve-2025-49005), [GHSA-r2fc-ccr8-96c4](https://github.com/vercel/next.js/security/advisories/GHSA-r2fc-ccr8-96c4)) — Cache poisoning via missing `Vary` header in Next.js 15.3.0–15.3.3. Workaround: manually set `Vary: RSC, Next-Router-State-Tree, Next-Router-Prefetch`
- **[Running Next.js behind AWS CloudFront](https://www.bstefanski.com/blog/running-nextjs-behind-aws-cloudfront)** — Documents the same cache poisoning issue and fix
- **[cdk-nextjs](https://github.com/jetbridge/cdk-nextjs)** `NextjsDistribution.ts` — Uses the same hash-into-single-header approach with `x-open-next-cache-key`
- **[CloudFront quotas](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-limits.html)** — Cache Policy allows max 10 headers