### PR TITLE
fix: pnpm を 10.34.4 に更新し pnpm -r run でルート実行ファイルを解決する

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: '22.x'
       - name: Install pnpm
-        run: corepack enable && corepack prepare pnpm@10.8.1 --activate
+        run: corepack enable && corepack prepare pnpm@10.34.4 --activate
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Check

--- a/package.json
+++ b/package.json
@@ -1,11 +1,5 @@
 {
   "private": true,
-  "simple-git-hooks": {
-    "pre-commit": "pnpm exec lint-staged && pnpm -r run test:unit"
-  },
-  "lint-staged": {
-    "*.{ts,tsx,js,jsx,mjs,cjs}": ["oxlint --config oxlintrc.json --fix", "oxfmt --write"]
-  },
   "scripts": {
     "prepare": "simple-git-hooks"
   },
@@ -17,7 +11,19 @@
     "oxlint-tsgolint": "^0",
     "simple-git-hooks": "^2.13.1"
   },
-  "packageManager": "pnpm@10.8.1",
+  "simple-git-hooks": {
+    "pre-commit": "pnpm exec lint-staged && pnpm -r run test:unit"
+  },
+  "lint-staged": {
+    "*.{ts,tsx,js,jsx,mjs,cjs}": [
+      "oxlint --config oxlintrc.json --fix",
+      "oxfmt --write"
+    ]
+  },
+  "engines": {
+    "pnpm": ">=10.26"
+  },
+  "packageManager": "pnpm@10.34.4",
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild",


### PR DESCRIPTION
## 概要

`pnpm -r run check:ci` がサブパッケージのスクリプト実行時に `oxlint: command not found` で失敗する問題を修正します。

## 背景 / 理由

`oxlint` / `oxfmt` / `oxlint-tsgolint` はルートの devDependencies にのみ宣言されています。pnpm の仕様では「ワークスペースでは `<workspace root>/node_modules/.bin` も PATH に追加され、ルートにインストールしたツールを各パッケージのスクリプトから呼べる」はずですが、この挙動が **pnpm 10.8.x / 10.9.x で regression** しており、`pnpm -r run` からルート専用ツールを解決できません。

二分探索で確認した結果:

| pnpm           | `pnpm -r run check:ci` |
| -------------- | ---------------------- |
| 10.8.1（現行） | ❌ command not found   |
| 10.9.0         | ❌                     |
| 10.12.1        | ✅                     |
| 10.16.0        | ✅                     |
| 10.34.4        | ✅                     |

## 変更内容

- `package.json`: `packageManager` を `pnpm@10.34.4` に更新し、`engines.pnpm` に `>=10.26` を追加。
- `.github/workflows/build.yml`: `corepack prepare` を `pnpm@10.34.4` に更新。

副次効果として、`pnpm-workspace.yaml` に既にあるが pnpm 10.8.1 では無効だった `minimumReleaseAge`（pnpm >=10.16 で有効）が機能するようになります。

## 補足（pnpm 11 を採用しない理由）

真の最新は pnpm 11.10.0 ですが、ignored build scripts がインストール時のハードエラー（`ERR_PNPM_IGNORED_BUILDS`）になる破壊的変更があり、そのままではビルドが通りません。別途 v11 移行作業が必要なため、本 PR では最新の 10.x（10.34.4）を採用します。

## 検証

- `pnpm install --frozen-lockfile`（CI 相当）→ 成功（lockfile 変化なし）
- `pnpm -r run check:ci` → 成功（command not found なし）
- `apps/cdk` build + test:unit → 成功

Closes #179
