### PR TITLE
fix(webapp): Amplify サーバー認証 Cookie に httpOnly/secure/sameSite を付与

### DIFF
--- a/apps/webapp/src/lib/amplifyServerUtils.ts
+++ b/apps/webapp/src/lib/amplifyServerUtils.ts
@@ -1,5 +1,8 @@
 import { createServerRunner } from '@aws-amplify/adapter-nextjs';
+import type { NextServer } from '@aws-amplify/adapter-nextjs';
 import { GetParameterCommand, SSMClient } from '@aws-sdk/client-ssm';
+
+type CreateServerRunnerRuntimeOptions = NextServer.CreateServerRunnerRuntimeOptions;
 
 if (process.env.AMPLIFY_APP_ORIGIN_SOURCE_PARAMETER) {
   const ssm = new SSMClient({});
@@ -30,9 +33,13 @@ export const { runWithAmplifyServerContext, createAuthRouteHandlers } = createSe
     },
   },
   runtimeOptions: {
+    // `httpOnly`/`secure` are supported by the underlying cookie storage but omitted from
+    // the adapter's public `cookies` type, so a cast is required here.
     cookies: {
       sameSite: 'lax',
+      httpOnly: true,
+      secure: true,
       maxAge: 60 * 60 * 24 * 7, // 7 days
-    },
+    } as CreateServerRunnerRuntimeOptions['cookies'],
   },
 });


### PR DESCRIPTION
## 概要

Amplify のサーバーサイド認証 Cookie にセキュア属性（`httpOnly` / `secure`）を付与します。

## 理由

`apps/webapp/src/lib/amplifyServerUtils.ts` の `createServerRunner` の `runtimeOptions.cookies` に `httpOnly` / `secure` が設定されておらず、XSS 発生時にトークンが JavaScript から読み取られるリスクがありました。セキュアデフォルトにします。

## 変更内容

- `runtimeOptions.cookies` に `httpOnly: true`, `secure: true` を追加（既存の `sameSite: 'lax'`, `maxAge` は維持）。
- アダプタの公開型が `httpOnly` / `secure` を絞り込みで除外しているため、型キャストを追加（実行時のクッキーストレージは両属性をサポート）。

## 検証

- `apps/webapp` の `next build` 成功、`test:unit` 16 tests 成功
- oxlint / oxfmt 0 warnings

Closes #175
