### PR TITLE
fix(cdk): CloudFront キャッシュキーに Next.js RSC ヘッダを追加

### DIFF
--- a/apps/cdk/lib/constructs/cf-lambda-furl-service/service.ts
+++ b/apps/cdk/lib/constructs/cf-lambda-furl-service/service.ts
@@ -89,6 +89,13 @@ export class CloudFrontLambdaFunctionUrlService extends Construct {
         'X-HTTP-Method-Override',
         'X-HTTP-Method',
         'X-Method-Override',
+        // Next.js App Router sends these headers on RSC navigation requests.
+        // Without them in the cache key, an RSC payload response could be cached
+        // and served for a plain HTML request (and vice versa), causing cache poisoning.
+        'RSC',
+        'Next-Router-Prefetch',
+        'Next-Router-State-Tree',
+        'Next-URL',
       ),
       defaultTtl: Duration.seconds(0),
       cookieBehavior: CacheCookieBehavior.all(),

--- a/apps/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit-without-domain.test.ts.snap
+++ b/apps/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit-without-domain.test.ts.snap
@@ -2969,6 +2969,10 @@ exports.handler = async function (event, context) {
                 "X-HTTP-Method-Override",
                 "X-HTTP-Method",
                 "X-Method-Override",
+                "RSC",
+                "Next-Router-Prefetch",
+                "Next-Router-State-Tree",
+                "Next-URL",
               ],
             },
             "QueryStringsConfig": {

--- a/apps/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit.test.ts.snap
+++ b/apps/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit.test.ts.snap
@@ -2793,6 +2793,10 @@ exports[`Snapshot test 2`] = `
                 "X-HTTP-Method-Override",
                 "X-HTTP-Method",
                 "X-Method-Override",
+                "RSC",
+                "Next-Router-Prefetch",
+                "Next-Router-State-Tree",
+                "Next-URL",
               ],
             },
             "QueryStringsConfig": {


### PR DESCRIPTION
## 概要

CloudFront の共有キャッシュポリシーに Next.js App Router の RSC 関連ヘッダを追加し、RSC ペイロードのキャッシュ汚染を防ぎます。

## 理由

`apps/cdk/lib/constructs/cf-lambda-furl-service/service.ts` の `SharedCachePolicy` の `headerBehavior.allowList` に RSC ヘッダが含まれていないため、prefetch / ソフトナビゲーション時に RSC ペイロード（`text/x-component`）が通常の HTML リクエストにもキャッシュされる汚染が起こり得ます（既知の Next.js + CDN の相互作用問題）。

## 変更内容

- `allowList` に `RSC` / `Next-Router-Prefetch` / `Next-Router-State-Tree` / `Next-URL` を追加。

## 検証

- `apps/cdk` build（tsc）成功
- CFn スナップショット更新（追加は当該4ヘッダのみ、他リソースの差分なし）、`test:unit` 成功
- oxlint / oxfmt OK

Closes #176
