### PR TITLE
feat(cdk): Auth construct に removalPolicy/deletionProtection を prop 化

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ cd apps/cdk
 pnpm exec cdk destroy --force
 ```
 
+The Aurora DSQL cluster and Cognito user pool are retained by default (`RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE`) and are not deleted by `cdk destroy`. Delete them manually afterward if they are no longer needed.
+
 ## Maintainers
 
 - [Kenji Kono (konokenj)](https://github.com/konokenj)

--- a/apps/cdk/lib/constructs/auth/index.ts
+++ b/apps/cdk/lib/constructs/auth/index.ts
@@ -22,6 +22,20 @@ export interface AuthProps {
    * @default No custom domain.
    */
   readonly sharedCertificate?: ICertificate;
+
+  /**
+   * Removal policy for the Cognito user pool.
+   *
+   * @default RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE
+   */
+  readonly removalPolicy?: RemovalPolicy;
+
+  /**
+   * Whether to enable deletion protection.
+   *
+   * @default false
+   */
+  readonly deletionProtectionEnabled?: boolean;
 }
 
 export class Auth extends Construct {
@@ -33,7 +47,11 @@ export class Auth extends Construct {
 
   constructor(scope: Construct, id: string, props: AuthProps) {
     super(scope, id);
-    const { hostedZone } = props;
+    const {
+      hostedZone,
+      removalPolicy = RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE,
+      deletionProtectionEnabled = false,
+    } = props;
     const subDomain = 'auth';
     let domainPrefix = '';
     if (!hostedZone) {
@@ -76,7 +94,8 @@ export class Auth extends Construct {
         username: false,
         email: true,
       },
-      removalPolicy: RemovalPolicy.DESTROY,
+      removalPolicy,
+      deletionProtection: deletionProtectionEnabled,
     });
 
     const client = userPool.addClient(`Client`, {

--- a/apps/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit-without-domain.test.ts.snap
+++ b/apps/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit-without-domain.test.ts.snap
@@ -1072,7 +1072,7 @@ exports[`Snapshot test 2`] = `
       "Type": "AWS::IAM::Policy",
     },
     "AuthUserPool8115E87F": {
-      "DeletionPolicy": "Delete",
+      "DeletionPolicy": "RetainExceptOnCreate",
       "Properties": {
         "AccountRecoverySetting": {
           "RecoveryMechanisms": [
@@ -1092,6 +1092,7 @@ exports[`Snapshot test 2`] = `
         "AutoVerifiedAttributes": [
           "email",
         ],
+        "DeletionProtection": "INACTIVE",
         "EmailVerificationMessage": "The verification code to your new account is {####}",
         "EmailVerificationSubject": "Verify your new account",
         "Policies": {
@@ -1114,7 +1115,7 @@ exports[`Snapshot test 2`] = `
         },
       },
       "Type": "AWS::Cognito::UserPool",
-      "UpdateReplacePolicy": "Delete",
+      "UpdateReplacePolicy": "Retain",
     },
     "AuthUserPoolClientC635291F": {
       "Properties": {

--- a/apps/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit.test.ts.snap
+++ b/apps/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit.test.ts.snap
@@ -983,7 +983,7 @@ exports[`Snapshot test 2`] = `
       "Type": "AWS::Route53::RecordSet",
     },
     "AuthUserPool8115E87F": {
-      "DeletionPolicy": "Delete",
+      "DeletionPolicy": "RetainExceptOnCreate",
       "Properties": {
         "AccountRecoverySetting": {
           "RecoveryMechanisms": [
@@ -1003,6 +1003,7 @@ exports[`Snapshot test 2`] = `
         "AutoVerifiedAttributes": [
           "email",
         ],
+        "DeletionProtection": "INACTIVE",
         "EmailVerificationMessage": "The verification code to your new account is {####}",
         "EmailVerificationSubject": "Verify your new account",
         "Policies": {
@@ -1025,7 +1026,7 @@ exports[`Snapshot test 2`] = `
         },
       },
       "Type": "AWS::Cognito::UserPool",
-      "UpdateReplacePolicy": "Delete",
+      "UpdateReplacePolicy": "Retain",
     },
     "AuthUserPoolClientC635291F": {
       "Properties": {


### PR DESCRIPTION
## 概要

Cognito UserPool の `removalPolicy` / `deletionProtection` を、既存の `Database` construct と同じ prop パターンで公開します。

## 理由

`apps/cdk/lib/constructs/auth/index.ts` が `RemovalPolicy.DESTROY` をハードコードしていました。UserPool は実ユーザーアカウントを保持する重要なステートフルリソースであり、スタックの削除・置換で意図せず失われる、事故につながりやすい既定でした。`Database` construct は既に同等の prop を持つため、それに揃えます。

## 変更内容

- `Auth` construct に `removalPolicy?`（既定 `RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE`）と `deletionProtectionEnabled?`（既定 `false`）を追加し、UserPool に適用。
- README の「Clean up」に、DSQL クラスタと Cognito UserPool は既定で保持され、完全削除は手動である旨を追記。

## 検証

- `apps/cdk` build 成功、`test:unit` 成功
- CFn スナップショット: UserPool の DeletionPolicy が `Delete` → `RetainExceptOnCreate`、UpdateReplacePolicy が `Retain` に変化（Database と同一の挙動）。他リソースの差分なし。

Closes #177
