### PR TITLE
fix(cdk): Lambda@Edge のバージョンを RETAIN し再デプロイ時の DELETE_FAILED を回避

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,6 +79,8 @@ See `packages/db/README.md` for full usage. Key rules:
 
 The webapp runs on Lambda behind CloudFront via Lambda Web Adapter (response streaming). `next.config.ts` uses `output: 'standalone'`. Build-time env vars (prefixed `NEXT_PUBLIC_`) are injected via CDK `ContainerImageBuild` build args — they cannot be changed at runtime.
 
+Lambda@Edge function versions (`edge-function.ts`) are retained (`RemovalPolicy.RETAIN`) instead of deleted by CDK, since CloudFront replica deletion is asynchronous and premature deletion causes `DELETE_FAILED`. Retained versions accumulate over deploys and must be deleted manually (via the Lambda console/CLI, after confirming they are no longer replicated to any edge location) if cleanup is needed.
+
 ### Real-time notifications
 
 Server → client push uses AppSync Events. Server-side: `sendEvent(channelName, payload)` with IAM SigV4 signing. Client-side: `useEventBus` hook with Cognito user pool auth. The channel namespace is `event-bus/`.

--- a/apps/cdk/lib/constructs/cf-lambda-furl-service/edge-function.ts
+++ b/apps/cdk/lib/constructs/cf-lambda-furl-service/edge-function.ts
@@ -1,4 +1,4 @@
-import { Stack } from 'aws-cdk-lib';
+import { RemovalPolicy, Stack } from 'aws-cdk-lib';
 import { PolicyStatement, ServicePrincipal, Role } from 'aws-cdk-lib/aws-iam';
 import { Runtime, IVersion, Version, Architecture } from 'aws-cdk-lib/aws-lambda';
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
@@ -26,6 +26,13 @@ export class EdgeFunction extends Construct {
     const handler = new NodejsFunction(this, 'Handler', {
       runtime: Runtime.NODEJS_22_X,
       entry: props.entryPath,
+      // CloudFront replicates Lambda@Edge versions to edge locations asynchronously,
+      // so a version can still be in use at edge locations when CloudFormation tries
+      // to delete it on stack update/destroy, causing DELETE_FAILED. Retain versions
+      // so deploys don't get stuck; stale versions must be cleaned up manually later.
+      currentVersionOptions: {
+        removalPolicy: RemovalPolicy.RETAIN,
+      },
     });
     handler.currentVersion;
     this.functionVersionParameter = new StringParameter(this, 'FunctionVersion', {

--- a/apps/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit-without-domain.test.ts.snap
+++ b/apps/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit-without-domain.test.ts.snap
@@ -129,6 +129,7 @@ exports[`Snapshot test 1`] = `
       "Type": "AWS::Lambda::Function",
     },
     "SignPayloadHandlerCurrentVersionREDACTED": {
+      "DeletionPolicy": "Retain",
       "Metadata": {
         "aws:cdk:do-not-refactor": true,
       },
@@ -138,6 +139,7 @@ exports[`Snapshot test 1`] = `
         },
       },
       "Type": "AWS::Lambda::Version",
+      "UpdateReplacePolicy": "Retain",
     },
     "SignPayloadHandlerFunctionVersionF9FE430A": {
       "Properties": {

--- a/apps/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit.test.ts.snap
+++ b/apps/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit.test.ts.snap
@@ -166,6 +166,7 @@ exports[`Snapshot test 1`] = `
       "Type": "AWS::Lambda::Function",
     },
     "SignPayloadHandlerCurrentVersionREDACTED": {
+      "DeletionPolicy": "Retain",
       "Metadata": {
         "aws:cdk:do-not-refactor": true,
       },
@@ -175,6 +176,7 @@ exports[`Snapshot test 1`] = `
         },
       },
       "Type": "AWS::Lambda::Version",
+      "UpdateReplacePolicy": "Retain",
     },
     "SignPayloadHandlerFunctionVersionF9FE430A": {
       "Properties": {


### PR DESCRIPTION
## 概要

Lambda@Edge のバージョンを `RemovalPolicy.RETAIN` にし、再デプロイ時の `DELETE_FAILED` 待ちを回避します。

## 理由

`signPayloadHandler`（Lambda@Edge）は全ユーザーが必ずデプロイします。CloudFront のレプリカ削除は非同期のため、更新・削除のたびに CloudFormation が旧バージョンを削除できず `DELETE_FAILED` となり、毎回数分の待ち（しかしスタック更新には成功する）が発生します。serverless 初学者を想定読者とする本キットにとって、原因の分かりにくい、繰り返し踏むつまずきになっていました。

## 変更内容

- `apps/cdk/lib/constructs/cf-lambda-furl-service/edge-function.ts` に `currentVersionOptions.removalPolicy = RemovalPolicy.RETAIN` を設定。
- `AGENTS.md` に、バージョンが保持され蓄積すること・必要に応じ手動削除する旨を追記。

## スコープ外（意図的に含めず）

- 蓄積した旧バージョンの掃除スクリプトはテンプレートに同梱しません（運用トピックであり過剰なため、ドキュメントの注記に留めています）。

## 検証

- `apps/cdk` build 成功、`test:unit` 成功
- CFn スナップショット: 当該 `AWS::Lambda::Version` に `DeletionPolicy: Retain` / `UpdateReplacePolicy: Retain` が付与。他リソースの差分なし。

Closes #178
