### PR TITLE
feat(webapp): API Route 認証ヘルパー withAuth() を追加し cognito-token を移行

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,8 @@ cd apps/webapp && pnpm run dev
 
 All server-side mutations must go through `authActionClient` (defined in `lib/safe-action.ts`). It validates the Cognito session via Amplify server-side auth and injects `ctx.userId`. Never call Drizzle directly from a Server Action without this middleware.
 
+API Routes (`app/api/**/route.ts`) must go through `withAuth()` (defined in `lib/api/with-auth.ts`) — the equivalent guardrail for Route Handlers. It resolves the session and returns 401 when unauthenticated; the handler receives the session and its return value is JSON-encoded. Validate inputs with Zod `safeParse`, same as Server Actions.
+
 `proxy.ts` handles route protection (redirect to `/sign-in` for unauthenticated users). It is NOT a Next.js middleware file — it runs inside the Lambda handler. There is no `middleware.ts` in this project.
 
 ### Async jobs
@@ -103,6 +105,7 @@ Server → client push uses AppSync Events. Server-side: `sendEvent(channelName,
 ## Do not
 
 - Do not bypass `authActionClient` for any mutation. No raw Drizzle calls from Server Actions.
+- Do not add an authenticated API Route without going through `withAuth()`.
 - Do not add `middleware.ts`. Route protection is handled by `proxy.ts` inside the Lambda runtime.
 - Do not hardcode AWS region or account IDs. Use CDK context or environment variables.
 - Do not add `NEXT_PUBLIC_` env vars to `.env.local` for deployed builds — they must be set as CDK build args in `webapp.ts`.

--- a/apps/webapp/src/app/api/cognito-token/route.ts
+++ b/apps/webapp/src/app/api/cognito-token/route.ts
@@ -1,10 +1,3 @@
-import { NextResponse } from 'next/server';
-import { tryGetAuthSession } from '@/lib/auth';
+import { withAuth } from '@/lib/api/with-auth';
 
-export async function GET() {
-  const session = await tryGetAuthSession();
-  if (session == null) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-  return NextResponse.json({ accessToken: session.accessToken });
-}
+export const GET = () => withAuth(async (session) => ({ accessToken: session.accessToken }));

--- a/apps/webapp/src/lib/api/with-auth.test.ts
+++ b/apps/webapp/src/lib/api/with-auth.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const tryGetAuthSession = vi.fn();
+vi.mock('@/lib/auth', () => ({ tryGetAuthSession: (...args: unknown[]) => tryGetAuthSession(...args) }));
+
+import { withAuth } from './with-auth';
+
+beforeEach(() => {
+  tryGetAuthSession.mockReset();
+});
+
+describe('withAuth', () => {
+  it('returns 401 when there is no authenticated session', async () => {
+    tryGetAuthSession.mockResolvedValue(null);
+    const handler = vi.fn();
+
+    const res = await withAuth(handler);
+
+    expect(res.status).toBe(401);
+    await expect(res.json()).resolves.toEqual({ error: 'Unauthorized' });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('calls the handler and returns its result when authenticated', async () => {
+    const session = {
+      userId: 'user-1',
+      email: 'user@example.com',
+      accessToken: 'access-token-value',
+    };
+    tryGetAuthSession.mockResolvedValue(session);
+    const handler = vi.fn().mockResolvedValue({ accessToken: session.accessToken });
+
+    const res = await withAuth(handler);
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ accessToken: 'access-token-value' });
+    expect(handler).toHaveBeenCalledWith(session);
+  });
+});

--- a/apps/webapp/src/lib/api/with-auth.ts
+++ b/apps/webapp/src/lib/api/with-auth.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import { tryGetAuthSession } from '@/lib/auth';
+
+type Session = NonNullable<Awaited<ReturnType<typeof tryGetAuthSession>>>;
+
+/**
+ * Auth guardrail for API Route handlers. Resolves the session and returns 401
+ * when unauthenticated; otherwise runs the handler and JSON-encodes its result.
+ */
+export async function withAuth<T>(handler: (session: Session) => Promise<T>): Promise<NextResponse> {
+  const session = await tryGetAuthSession();
+  if (session == null) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const result = await handler(session);
+  return NextResponse.json(result);
+}


### PR DESCRIPTION
## 概要

API Route 用の認証ガードレール `withAuth()` を追加し、既存の認証必須 API Route（`cognito-token`）をそれ経由に移行します。Server Action における `authActionClient` と対になる仕組みです。

## 理由

`authActionClient` が「全ミューテーションはこれを通す」という必須ラッパーを Server Action に課している一方で、もう一方のデータ入口である API Route には等価のガードがありませんでした。実際にキット自身の `apps/webapp/src/app/api/cognito-token/route.ts` が `tryGetAuthSession` + 401 応答を手書きしています。`withAuth()` はこの非対称を埋め、認証チェックの書き忘れを構造的に防ぎます（pit-of-success 型のセキュリティ設計）。

## 変更内容

- `apps/webapp/src/lib/api/with-auth.ts`: `withAuth(handler)` を追加。未認証なら 401（`{ error: 'Unauthorized' }`）、認証済みならハンドラを実行し結果を JSON 化する薄い HOF。
- `apps/webapp/src/app/api/cognito-token/route.ts`: `withAuth()` の利用者にリファクタ（既存の重複を除去）。
- `apps/webapp/src/lib/api/with-auth.test.ts`: 401 / 認証成功の単体テストを追加。
- `AGENTS.md`: 「API Route は `withAuth()` を通す。入力は Zod `safeParse` で検証」を明文化（Do-not にも追記）。

## スコープ外

- Bearer トークンや dual-auth などアプリ固有の認証方式は含めません（汎用な HOF の形のみ）。

## 検証

- `apps/webapp` build 成功、`test:unit` 18 tests 成功（既存の `cognito-token/route.test.ts` を無改変で維持し green）
- oxlint / oxfmt OK

Closes #124
