### PR TITLE
feat(cdk)!: support CloudFront flat-rate pricing plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,14 @@ ServerlessWebappStarterKitStack.DatabaseClusterEndpoint = <cluster>.dsql.<region
 
 Open the `FrontendDomainName` URL to try the sample app.
 
-### 4. Add your own features
+### 4. Enroll in the CloudFront Free plan
+
+The kit deploys a WAF Web ACL because CloudFront [flat-rate pricing plans](https://aws.amazon.com/cloudfront/pricing/) require one. In the CloudFront console, open your distribution and choose **Manage subscription → Free plan** (1M requests + 100 GB/month, no extra cost). Plan enrollment is not supported by CDK, so this is a one-time manual step.
+
+> [!WARNING]
+> Until you enroll, the Web ACL is billed at [standard AWS WAF prices](https://aws.amazon.com/waf/pricing/) (~$5/month + $1/month per rule). Enroll in the Free plan to bundle WAF at no extra cost, or [remove the Web ACL](#cloudfront-flat-rate-pricing-plan) if you don't want it.
+
+### 5. Add your own features
 
 See [`AGENTS.md`](./AGENTS.md) for development guide — local development setup, authentication patterns, async job setup, DB migration, and coding conventions.
 
@@ -144,6 +151,17 @@ Sample cost breakdown for us-east-1, one month, with cost-optimized configuratio
 | **Total**      |                                                  | **2.42**           |
 
 Assumes 100 users/month, 1000 requests/user. Costs could be further reduced with [Free Tier](https://aws.amazon.com/free/). No VPC or NAT costs — DSQL uses IAM authentication over the public internet.
+
+### CloudFront flat-rate pricing plan
+
+CloudFront [flat-rate pricing plans](https://aws.amazon.com/cloudfront/pricing/) (Free / Pro / Business / Premium) bundle CDN, AWS WAF, DDoS protection, and CloudWatch Logs at a fixed price; the **Free plan** is $0 for 1M requests + 100 GB/month. Enroll from the console after deploying (see [step 4](#4-enroll-in-the-cloudfront-free-plan)).
+
+The kit is configured for these plans by default:
+
+- Managed cache policies only (custom policies are not allowed): `CACHING_DISABLED` for the default behavior + `CACHING_OPTIMIZED` for `/_next/static/*` — 2 of the 5 allowed cache behaviors.
+- A required WAF Web ACL (`us-east-1`, scope `CLOUDFRONT`) carrying only `KnownBadInputs`. Rate limiting, `AmazonIpReputationList`, and `CommonRuleSet` are omitted to avoid opaque false positives (rate / IP-reputation 403s, blocks on large auth cookies or missing User-Agent).
+
+To opt out of WAF entirely, remove the Web ACL in [`apps/cdk/lib/us-east-1-stack.ts`](apps/cdk/lib/us-east-1-stack.ts) and drop `webAclId` from [`apps/cdk/bin/cdk.ts`](apps/cdk/bin/cdk.ts). The plan covers CloudFront-side usage only — Lambda / Lambda@Edge (dynamic requests are all cache-missed) are billed separately. To restrict access geographically, set `geoRestriction` in `bin/cdk.ts` (e.g. `GeoRestriction.allowlist('JP')`).
 
 ## Clean up
 

--- a/apps/cdk/bin/cdk.ts
+++ b/apps/cdk/bin/cdk.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
+import { GeoRestriction } from 'aws-cdk-lib/aws-cloudfront';
 import { MainStack } from '../lib/main-stack';
 import { UsEast1Stack } from '../lib/us-east-1-stack';
 
@@ -18,11 +19,20 @@ interface EnvironmentProps {
    * and uses the CloudFront default domain (e.g., d1234567890.cloudfront.net) for the webapp.
    */
   domainName?: string;
+
+  /**
+   * Geographic restriction for the CloudFront distribution
+   * (e.g. `GeoRestriction.allowlist('JP')` or `GeoRestriction.denylist('CN')`).
+   *
+   * @default No geographic restriction.
+   */
+  geoRestriction?: GeoRestriction;
 }
 
 const props: EnvironmentProps = {
   account: process.env.CDK_DEFAULT_ACCOUNT!,
   // domainName: 'FIXME.example.com',
+  // geoRestriction: GeoRestriction.allowlist('JP'),
 };
 
 const virginia = new UsEast1Stack(app, 'ServerlessWebappStarterKitUsEast1Stack', {
@@ -42,6 +52,8 @@ new MainStack(app, 'ServerlessWebappStarterKitStack', {
   sharedCertificate: virginia.certificate,
   domainName: props.domainName,
   signPayloadHandler: virginia.signPayloadHandler,
+  webAclId: virginia.webAclArn,
+  geoRestriction: props.geoRestriction,
 });
 
 cdk.Tags.of(app).add('Application', 'ServerlessFullStackWebappStarterKit');

--- a/apps/cdk/lib/constructs/cf-lambda-furl-service/service.ts
+++ b/apps/cdk/lib/constructs/cf-lambda-furl-service/service.ts
@@ -3,11 +3,9 @@ import { Aws, Duration } from 'aws-cdk-lib';
 import { FunctionUrlAuthType, Function, InvokeMode, CfnPermission } from 'aws-cdk-lib/aws-lambda';
 import {
   AllowedMethods,
-  CacheCookieBehavior,
-  CacheHeaderBehavior,
   CachePolicy,
-  CacheQueryStringBehavior,
   Distribution,
+  GeoRestriction,
   LambdaEdgeEventType,
   OriginRequestPolicy,
   SecurityPolicyProtocol,
@@ -55,6 +53,25 @@ export interface CloudFrontLambdaFunctionUrlServiceProps {
   certificate?: ICertificate;
   signPayloadHandler: EdgeFunction;
   accessLogBucket: Bucket;
+
+  /**
+   * ARN of a WAF Web ACL (scope=CLOUDFRONT, must be created in us-east-1) to associate
+   * with the distribution.
+   *
+   * Required to enroll the distribution in a CloudFront flat-rate pricing plan
+   * (Free/Pro/Business/Premium), which mandates an associated Web ACL. Leave unset for
+   * the default pay-as-you-go setup (no Web ACL is associated).
+   *
+   * @default No Web ACL is associated (pay-as-you-go).
+   */
+  webAclId?: string;
+
+  /**
+   * Geographic restriction for the distribution (e.g. `GeoRestriction.allowlist('JP')`).
+   *
+   * @default No geographic restriction.
+   */
+  geoRestriction?: GeoRestriction;
 }
 
 export class CloudFrontLambdaFunctionUrlService extends Construct {
@@ -64,7 +81,17 @@ export class CloudFrontLambdaFunctionUrlService extends Construct {
 
   constructor(scope: Construct, id: string, props: CloudFrontLambdaFunctionUrlServiceProps) {
     super(scope, id);
-    const { handler, serviceName, subDomain, hostedZone, certificate, accessLogBucket, signPayloadHandler } = props;
+    const {
+      handler,
+      serviceName,
+      subDomain,
+      hostedZone,
+      certificate,
+      accessLogBucket,
+      signPayloadHandler,
+      webAclId,
+      geoRestriction,
+    } = props;
     let domainName = '';
     if (hostedZone) {
       domainName = subDomain ? `${subDomain}.${hostedZone.zoneName}` : hostedZone.zoneName;
@@ -79,43 +106,59 @@ export class CloudFrontLambdaFunctionUrlService extends Construct {
       readTimeout: Duration.seconds(60),
     });
 
-    const cachePolicy = new CachePolicy(this, 'SharedCachePolicy', {
-      queryStringBehavior: CacheQueryStringBehavior.all(),
-      headerBehavior: CacheHeaderBehavior.allowList(
-        // CachePolicy.USE_ORIGIN_CACHE_CONTROL_HEADERS_QUERY_STRINGS contains Host header here,
-        // making it impossible to use with API Gateway
-        'authorization',
-        'Origin',
-        'X-HTTP-Method-Override',
-        'X-HTTP-Method',
-        'X-Method-Override',
-      ),
-      defaultTtl: Duration.seconds(0),
-      cookieBehavior: CacheCookieBehavior.all(),
-      enableAcceptEncodingBrotli: true,
-      enableAcceptEncodingGzip: true,
-    });
+    // CloudFront flat-rate pricing plan (Free/Pro) compatibility: custom cache policies are
+    // only available on Business/Premium, so we use AWS managed cache policies only.
+    //
+    // Default behavior uses CachePolicy.CACHING_DISABLED (min/max/default TTL = 0):
+    //   - CloudFront never caches dynamic responses, so there is no cross-user cache pollution
+    //     risk; Cookie/Authorization need not be part of the cache key. This also structurally
+    //     resolves the Next.js App Router RSC payload cache pollution issue (nothing to pollute).
+    //   - Requests (headers/cookies/query string/body) are still forwarded to the origin via
+    //     OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER, so request handling is unchanged.
+    //   - App-level compression (gzip/brotli) is handled at the origin by Lambda Web Adapter +
+    //     Next.js, so CloudFront's automatic compression on this behavior is unnecessary.
+    //
+    // /_next/static/* uses CachePolicy.CACHING_OPTIMIZED so immutable, content-hashed build
+    // assets are cached at the edge instead of hitting the Lambda origin on every request. These
+    // assets are public and vary only by path, so the managed policy's cache key (no cookies, no
+    // query strings) is safe; Next.js serves them with `Cache-Control: public, max-age=31536000,
+    // immutable`. The origin-request signer runs only on cache misses. This is a second cache
+    // behavior (flat-rate Free allows up to 5).
+    const edgeLambdas = [
+      {
+        functionVersion: signPayloadHandler.versionArn(this),
+        eventType: LambdaEdgeEventType.ORIGIN_REQUEST,
+        includeBody: true,
+      },
+    ];
 
     const distribution = new Distribution(this, 'Resource', {
       comment: `CloudFront for ${serviceName}`,
       defaultBehavior: {
         origin,
-        cachePolicy,
+        cachePolicy: CachePolicy.CACHING_DISABLED,
         allowedMethods: AllowedMethods.ALLOW_ALL,
         originRequestPolicy: OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
-        edgeLambdas: [
-          {
-            functionVersion: signPayloadHandler.versionArn(this),
-            eventType: LambdaEdgeEventType.ORIGIN_REQUEST,
-            includeBody: true,
-          },
-        ],
+        edgeLambdas,
+      },
+      additionalBehaviors: {
+        '/_next/static/*': {
+          origin,
+          cachePolicy: CachePolicy.CACHING_OPTIMIZED,
+          allowedMethods: AllowedMethods.ALLOW_GET_HEAD,
+          originRequestPolicy: OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER,
+          edgeLambdas,
+        },
       },
       // errorResponses: [{ httpStatus: 404, responsePagePath: '/', responseHttpStatus: 200 }],
       logBucket: accessLogBucket,
       logFilePrefix: `${serviceName}/`,
 
       ...(hostedZone ? { certificate: certificate, domainNames: [domainName] } : {}),
+
+      // Associate a WAF Web ACL / geo restriction only when provided (required for flat-rate plans).
+      ...(webAclId ? { webAclId } : {}),
+      ...(geoRestriction ? { geoRestriction } : {}),
 
       minimumProtocolVersion: SecurityPolicyProtocol.TLS_V1_2_2021,
     });

--- a/apps/cdk/lib/constructs/webapp.ts
+++ b/apps/cdk/lib/constructs/webapp.ts
@@ -4,6 +4,7 @@ import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import { DockerImageFunction, Architecture } from 'aws-cdk-lib/aws-lambda';
 import { Construct } from 'constructs';
 import { CloudFrontLambdaFunctionUrlService } from './cf-lambda-furl-service/service';
+import { GeoRestriction } from 'aws-cdk-lib/aws-cloudfront';
 import { IHostedZone } from 'aws-cdk-lib/aws-route53';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
 import { Database } from './database';
@@ -43,6 +44,21 @@ export interface WebappProps {
    * @default Use root domain
    */
   subDomain?: string;
+
+  /**
+   * ARN of a WAF Web ACL (scope=CLOUDFRONT, us-east-1) to associate with the CloudFront
+   * distribution. Required to enroll in a CloudFront flat-rate pricing plan.
+   *
+   * @default No Web ACL is associated (pay-as-you-go).
+   */
+  webAclId?: string;
+
+  /**
+   * Geographic restriction for the CloudFront distribution.
+   *
+   * @default No geographic restriction.
+   */
+  geoRestriction?: GeoRestriction;
 }
 
 export class Webapp extends Construct {
@@ -96,6 +112,8 @@ export class Webapp extends Construct {
       certificate: props.certificate,
       accessLogBucket: props.accessLogBucket,
       signPayloadHandler: props.signPayloadHandler,
+      webAclId: props.webAclId,
+      geoRestriction: props.geoRestriction,
     });
     this.baseUrl = service.url;
 

--- a/apps/cdk/lib/main-stack.ts
+++ b/apps/cdk/lib/main-stack.ts
@@ -6,6 +6,7 @@ import { Auth } from './constructs/auth/';
 import { Database } from './constructs/database';
 import { HostedZone } from 'aws-cdk-lib/aws-route53';
 import { ICertificate } from 'aws-cdk-lib/aws-certificatemanager';
+import { GeoRestriction } from 'aws-cdk-lib/aws-cloudfront';
 import { Webapp } from './constructs/webapp';
 import { EdgeFunction } from './constructs/cf-lambda-furl-service/edge-function';
 import { EventBus } from './constructs/event-bus/';
@@ -26,6 +27,21 @@ interface MainStackProps extends StackProps {
    * @default No custom domain.
    */
   readonly sharedCertificate?: ICertificate;
+
+  /**
+   * ARN of a WAF Web ACL (scope=CLOUDFRONT, created in us-east-1) to associate with the
+   * CloudFront distribution. Required to enroll in a CloudFront flat-rate pricing plan.
+   *
+   * @default No Web ACL is associated (pay-as-you-go).
+   */
+  readonly webAclId?: string;
+
+  /**
+   * Geographic restriction for the CloudFront distribution.
+   *
+   * @default No geographic restriction.
+   */
+  readonly geoRestriction?: GeoRestriction;
 }
 
 export class MainStack extends Stack {
@@ -72,6 +88,8 @@ export class MainStack extends Stack {
       eventBus,
       asyncJob,
       subDomain: 'web',
+      webAclId: props.webAclId,
+      geoRestriction: props.geoRestriction,
     });
 
     new DsqlMigrator(this, 'DsqlMigrator', { database });

--- a/apps/cdk/lib/us-east-1-stack.ts
+++ b/apps/cdk/lib/us-east-1-stack.ts
@@ -1,5 +1,6 @@
 import * as cdk from 'aws-cdk-lib';
 import { Certificate, CertificateValidation, ICertificate } from 'aws-cdk-lib/aws-certificatemanager';
+import { CfnWebACL } from 'aws-cdk-lib/aws-wafv2';
 import { ARecord, HostedZone, RecordTarget } from 'aws-cdk-lib/aws-route53';
 import { Construct } from 'constructs';
 import { EdgeFunction } from './constructs/cf-lambda-furl-service/edge-function';
@@ -24,6 +25,11 @@ export class UsEast1Stack extends cdk.Stack {
    * the signer L@E function (it must be deployed in us-east-1).
    */
   public readonly signPayloadHandler: EdgeFunction;
+  /**
+   * ARN of the WAF Web ACL (scope=CLOUDFRONT) associated with the CloudFront distribution.
+   * Required for the CloudFront flat-rate pricing plan.
+   */
+  public readonly webAclArn: string;
 
   constructor(scope: Construct, id: string, props: UsEast1StackProps) {
     super(scope, id, props);
@@ -54,5 +60,47 @@ export class UsEast1Stack extends cdk.Stack {
     });
 
     this.signPayloadHandler = signPayloadHandler;
+
+    // WAF Web ACL associated with the CloudFront distribution. Required for the CloudFront
+    // flat-rate pricing plan (an associated Web ACL is mandatory to enroll).
+    //
+    // Intentionally minimal to avoid hard-to-diagnose false positives in a starter kit:
+    //   - No rate-based rule: trips on shared NAT / corporate proxies, load tests, and Next.js
+    //     prefetch bursts, blocking legitimate users with an opaque 403.
+    //   - No AmazonIpReputationList: blocks specific users by source-IP reputation with no
+    //     request-content cause — impossible for the user to understand.
+    //   - No CommonRuleSet: its NoUserAgent_HEADER and SizeRestrictions_Cookie rules false-positive
+    //     on health checks / server-side fetches and on large Amplify/Cognito auth cookies.
+    // Only KnownBadInputs is kept: it matches actual exploit signatures (e.g. Log4Shell) that do
+    // not appear in legitimate traffic, so it blocks nothing a real user would send. Add more
+    // managed rule groups (up to the Free plan's 5-rule limit) once you understand your traffic.
+    const webAcl = new CfnWebACL(this, 'WebAcl', {
+      scope: 'CLOUDFRONT',
+      defaultAction: { allow: {} },
+      visibilityConfig: {
+        cloudWatchMetricsEnabled: true,
+        metricName: 'WebappWebAcl',
+        sampledRequestsEnabled: true,
+      },
+      rules: [
+        {
+          name: 'AWSManagedKnownBadInputs',
+          priority: 1,
+          overrideAction: { none: {} },
+          statement: {
+            managedRuleGroupStatement: {
+              vendorName: 'AWS',
+              name: 'AWSManagedRulesKnownBadInputsRuleSet',
+            },
+          },
+          visibilityConfig: {
+            cloudWatchMetricsEnabled: true,
+            metricName: 'KnownBadInputs',
+            sampledRequestsEnabled: true,
+          },
+        },
+      ],
+    });
+    this.webAclArn = webAcl.attrArn;
   }
 }

--- a/apps/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit-without-domain.test.ts.snap
+++ b/apps/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit-without-domain.test.ts.snap
@@ -98,6 +98,12 @@ exports[`Snapshot test 1`] = `
         },
         "WriterProps": {
           "exports": {
+            "/cdk/exports/ServerlessWebappStarterKitStack/ServerlessWebappStarterKitUsEast1Stackuseast1FnGetAttWebAclArn95310D3C": {
+              "Fn::GetAtt": [
+                "WebAcl",
+                "Arn",
+              ],
+            },
             "/cdk/exports/ServerlessWebappStarterKitStack/ServerlessWebappStarterKitUsEast1Stackuseast1RefSignPayloadHandlerFunctionVersionF9FE430A3006B9FA": {
               "Ref": "SignPayloadHandlerFunctionVersionF9FE430A",
             },
@@ -187,6 +193,40 @@ exports[`Snapshot test 1`] = `
         ],
       },
       "Type": "AWS::IAM::Role",
+    },
+    "WebAcl": {
+      "Properties": {
+        "DefaultAction": {
+          "Allow": {},
+        },
+        "Rules": [
+          {
+            "Name": "AWSManagedKnownBadInputs",
+            "OverrideAction": {
+              "None": {},
+            },
+            "Priority": 1,
+            "Statement": {
+              "ManagedRuleGroupStatement": {
+                "Name": "AWSManagedRulesKnownBadInputsRuleSet",
+                "VendorName": "AWS",
+              },
+            },
+            "VisibilityConfig": {
+              "CloudWatchMetricsEnabled": true,
+              "MetricName": "KnownBadInputs",
+              "SampledRequestsEnabled": true,
+            },
+          },
+        ],
+        "Scope": "CLOUDFRONT",
+        "VisibilityConfig": {
+          "CloudWatchMetricsEnabled": true,
+          "MetricName": "WebappWebAcl",
+          "SampledRequestsEnabled": true,
+        },
+      },
+      "Type": "AWS::WAFv2::WebACL",
     },
   },
   "Rules": {
@@ -2058,6 +2098,7 @@ exports[`Snapshot test 2`] = `
       "Properties": {
         "ReaderProps": {
           "imports": {
+            "/cdk/exports/ServerlessWebappStarterKitStack/ServerlessWebappStarterKitUsEast1Stackuseast1FnGetAttWebAclArn95310D3C": "{{resolve:ssm:/cdk/exports/ServerlessWebappStarterKitStack/ServerlessWebappStarterKitUsEast1Stackuseast1FnGetAttWebAclArn95310D3C}}",
             "/cdk/exports/ServerlessWebappStarterKitStack/ServerlessWebappStarterKitUsEast1Stackuseast1RefSignPayloadHandlerFunctionVersionF9FE430A3006B9FA": "{{resolve:ssm:/cdk/exports/ServerlessWebappStarterKitStack/ServerlessWebappStarterKitUsEast1Stackuseast1RefSignPayloadHandlerFunctionVersionF9FE430A3006B9FA}}",
           },
           "prefix": "ServerlessWebappStarterKitStack",
@@ -2322,6 +2363,32 @@ exports.handler = async function (event, context) {
     "Webapp107041BD": {
       "Properties": {
         "DistributionConfig": {
+          "CacheBehaviors": [
+            {
+              "AllowedMethods": [
+                "GET",
+                "HEAD",
+              ],
+              "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+              "Compress": true,
+              "LambdaFunctionAssociations": [
+                {
+                  "EventType": "origin-request",
+                  "IncludeBody": true,
+                  "LambdaFunctionARN": {
+                    "Fn::GetAtt": [
+                      "LookupVersionArnc8730278af02f875114ca902814c77b68f19b0087110E04D0A",
+                      "Parameter.Value",
+                    ],
+                  },
+                },
+              ],
+              "OriginRequestPolicyId": "b689b0a8-53d0-40ab-baf2-68738e2966ac",
+              "PathPattern": "/_next/static/*",
+              "TargetOriginId": "ServerlessWebappStarterKitStackWebappOrigin1D7B867FF",
+              "ViewerProtocolPolicy": "allow-all",
+            },
+          ],
           "Comment": "CloudFront for Webapp",
           "DefaultCacheBehavior": {
             "AllowedMethods": [
@@ -2333,9 +2400,7 @@ exports.handler = async function (event, context) {
               "POST",
               "DELETE",
             ],
-            "CachePolicyId": {
-              "Ref": "WebappSharedCachePolicy14FEE4A0",
-            },
+            "CachePolicyId": "4135ea2d-6df8-44a3-9df3-4b5a84be39ad",
             "Compress": true,
             "LambdaFunctionAssociations": [
               {
@@ -2400,6 +2465,12 @@ exports.handler = async function (event, context) {
               },
             },
           ],
+          "WebACLId": {
+            "Fn::GetAtt": [
+              "ExportsReader8B249524",
+              "/cdk/exports/ServerlessWebappStarterKitStack/ServerlessWebappStarterKitUsEast1Stackuseast1FnGetAttWebAclArn95310D3C",
+            ],
+          },
         },
       },
       "Type": "AWS::CloudFront::Distribution",
@@ -2962,37 +3033,6 @@ exports.handler = async function (event, context) {
         "Value": "dummy",
       },
       "Type": "AWS::SSM::Parameter",
-    },
-    "WebappSharedCachePolicy14FEE4A0": {
-      "Properties": {
-        "CachePolicyConfig": {
-          "DefaultTTL": 0,
-          "MaxTTL": 31536000,
-          "MinTTL": 0,
-          "Name": "ServerlessWebappStarterKitStackWebappSharedCachePolicy211E133B-us-west-2",
-          "ParametersInCacheKeyAndForwardedToOrigin": {
-            "CookiesConfig": {
-              "CookieBehavior": "all",
-            },
-            "EnableAcceptEncodingBrotli": true,
-            "EnableAcceptEncodingGzip": true,
-            "HeadersConfig": {
-              "HeaderBehavior": "whitelist",
-              "Headers": [
-                "authorization",
-                "Origin",
-                "X-HTTP-Method-Override",
-                "X-HTTP-Method",
-                "X-Method-Override",
-              ],
-            },
-            "QueryStringsConfig": {
-              "QueryStringBehavior": "all",
-            },
-          },
-        },
-      },
-      "Type": "AWS::CloudFront::CachePolicy",
     },
     "WebappUpdateAmplifyOriginSourceParameter3F609A08": {
       "DeletionPolicy": "Delete",

--- a/apps/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit.test.ts.snap
+++ b/apps/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit.test.ts.snap
@@ -120,6 +120,12 @@ exports[`Snapshot test 1`] = `
         },
         "WriterProps": {
           "exports": {
+            "/cdk/exports/ServerlessWebappStarterKitStack/ServerlessWebappStarterKitUsEast1Stackuseast1FnGetAttWebAclArn95310D3C": {
+              "Fn::GetAtt": [
+                "WebAcl",
+                "Arn",
+              ],
+            },
             "/cdk/exports/ServerlessWebappStarterKitStack/ServerlessWebappStarterKitUsEast1Stackuseast1RefCertificateV29EE77EAF5C85697F": {
               "Ref": "CertificateV29EE77EAF",
             },
@@ -224,6 +230,40 @@ exports[`Snapshot test 1`] = `
         ],
       },
       "Type": "AWS::IAM::Role",
+    },
+    "WebAcl": {
+      "Properties": {
+        "DefaultAction": {
+          "Allow": {},
+        },
+        "Rules": [
+          {
+            "Name": "AWSManagedKnownBadInputs",
+            "OverrideAction": {
+              "None": {},
+            },
+            "Priority": 1,
+            "Statement": {
+              "ManagedRuleGroupStatement": {
+                "Name": "AWSManagedRulesKnownBadInputsRuleSet",
+                "VendorName": "AWS",
+              },
+            },
+            "VisibilityConfig": {
+              "CloudWatchMetricsEnabled": true,
+              "MetricName": "KnownBadInputs",
+              "SampledRequestsEnabled": true,
+            },
+          },
+        ],
+        "Scope": "CLOUDFRONT",
+        "VisibilityConfig": {
+          "CloudWatchMetricsEnabled": true,
+          "MetricName": "WebappWebAcl",
+          "SampledRequestsEnabled": true,
+        },
+      },
+      "Type": "AWS::WAFv2::WebACL",
     },
   },
   "Rules": {
@@ -1974,6 +2014,7 @@ exports[`Snapshot test 2`] = `
       "Properties": {
         "ReaderProps": {
           "imports": {
+            "/cdk/exports/ServerlessWebappStarterKitStack/ServerlessWebappStarterKitUsEast1Stackuseast1FnGetAttWebAclArn95310D3C": "{{resolve:ssm:/cdk/exports/ServerlessWebappStarterKitStack/ServerlessWebappStarterKitUsEast1Stackuseast1FnGetAttWebAclArn95310D3C}}",
             "/cdk/exports/ServerlessWebappStarterKitStack/ServerlessWebappStarterKitUsEast1Stackuseast1RefCertificateV29EE77EAF5C85697F": "{{resolve:ssm:/cdk/exports/ServerlessWebappStarterKitStack/ServerlessWebappStarterKitUsEast1Stackuseast1RefCertificateV29EE77EAF5C85697F}}",
             "/cdk/exports/ServerlessWebappStarterKitStack/ServerlessWebappStarterKitUsEast1Stackuseast1RefSignPayloadHandlerFunctionVersionF9FE430A3006B9FA": "{{resolve:ssm:/cdk/exports/ServerlessWebappStarterKitStack/ServerlessWebappStarterKitUsEast1Stackuseast1RefSignPayloadHandlerFunctionVersionF9FE430A3006B9FA}}",
           },
@@ -2157,6 +2198,32 @@ exports[`Snapshot test 2`] = `
           "Aliases": [
             "web.example.com",
           ],
+          "CacheBehaviors": [
+            {
+              "AllowedMethods": [
+                "GET",
+                "HEAD",
+              ],
+              "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+              "Compress": true,
+              "LambdaFunctionAssociations": [
+                {
+                  "EventType": "origin-request",
+                  "IncludeBody": true,
+                  "LambdaFunctionARN": {
+                    "Fn::GetAtt": [
+                      "LookupVersionArnc8730278af02f875114ca902814c77b68f19b0087110E04D0A",
+                      "Parameter.Value",
+                    ],
+                  },
+                },
+              ],
+              "OriginRequestPolicyId": "b689b0a8-53d0-40ab-baf2-68738e2966ac",
+              "PathPattern": "/_next/static/*",
+              "TargetOriginId": "ServerlessWebappStarterKitStackWebappOrigin1D7B867FF",
+              "ViewerProtocolPolicy": "allow-all",
+            },
+          ],
           "Comment": "CloudFront for Webapp",
           "DefaultCacheBehavior": {
             "AllowedMethods": [
@@ -2168,9 +2235,7 @@ exports[`Snapshot test 2`] = `
               "POST",
               "DELETE",
             ],
-            "CachePolicyId": {
-              "Ref": "WebappSharedCachePolicy14FEE4A0",
-            },
+            "CachePolicyId": "4135ea2d-6df8-44a3-9df3-4b5a84be39ad",
             "Compress": true,
             "LambdaFunctionAssociations": [
               {
@@ -2244,6 +2309,12 @@ exports[`Snapshot test 2`] = `
             },
             "MinimumProtocolVersion": "TLSv1.2_2021",
             "SslSupportMethod": "sni-only",
+          },
+          "WebACLId": {
+            "Fn::GetAtt": [
+              "ExportsReader8B249524",
+              "/cdk/exports/ServerlessWebappStarterKitStack/ServerlessWebappStarterKitUsEast1Stackuseast1FnGetAttWebAclArn95310D3C",
+            ],
           },
         },
       },
@@ -2786,37 +2857,6 @@ exports[`Snapshot test 2`] = `
         "Type": "A",
       },
       "Type": "AWS::Route53::RecordSet",
-    },
-    "WebappSharedCachePolicy14FEE4A0": {
-      "Properties": {
-        "CachePolicyConfig": {
-          "DefaultTTL": 0,
-          "MaxTTL": 31536000,
-          "MinTTL": 0,
-          "Name": "ServerlessWebappStarterKitStackWebappSharedCachePolicy211E133B-us-west-2",
-          "ParametersInCacheKeyAndForwardedToOrigin": {
-            "CookiesConfig": {
-              "CookieBehavior": "all",
-            },
-            "EnableAcceptEncodingBrotli": true,
-            "EnableAcceptEncodingGzip": true,
-            "HeadersConfig": {
-              "HeaderBehavior": "whitelist",
-              "Headers": [
-                "authorization",
-                "Origin",
-                "X-HTTP-Method-Override",
-                "X-HTTP-Method",
-                "X-Method-Override",
-              ],
-            },
-            "QueryStringsConfig": {
-              "QueryStringBehavior": "all",
-            },
-          },
-        },
-      },
-      "Type": "AWS::CloudFront::CachePolicy",
     },
   },
   "Rules": {

--- a/apps/cdk/test/cloudfront-free-plan.test.ts
+++ b/apps/cdk/test/cloudfront-free-plan.test.ts
@@ -1,0 +1,87 @@
+import * as cdk from 'aws-cdk-lib';
+import { Template } from 'aws-cdk-lib/assertions';
+import { MainStack } from '../lib/main-stack';
+import { UsEast1Stack } from '../lib/us-east-1-stack';
+
+// Managed CachePolicy.CACHING_DISABLED id (min/max/default TTL = 0). Flat-rate Free/Pro plans
+// forbid custom cache policies, so the default behavior must reference this managed policy.
+const CACHING_DISABLED_ID = '4135ea2d-6df8-44a3-9df3-4b5a84be39ad';
+
+// Managed CachePolicy.CACHING_OPTIMIZED id. Used for immutable /_next/static assets so they are
+// edge-cached instead of hitting the Lambda origin on every request.
+const CACHING_OPTIMIZED_ID = '658327ea-f89d-4fab-a63d-7e88639e58f6';
+
+const account = '123456789012';
+
+function getDistributionConfig(template: Template) {
+  const distributions = template.findResources('AWS::CloudFront::Distribution');
+  return Object.values(distributions)[0].Properties.DistributionConfig as Record<string, unknown>;
+}
+
+// Mirrors bin/cdk.ts: the us-east-1 stack always provisions the CLOUDFRONT Web ACL, and its ARN
+// is passed to the main stack so the distribution is enrolled in the flat-rate pricing plan.
+function synth() {
+  const app = new cdk.App();
+  const virginia = new UsEast1Stack(app, 'UsEast1Stack', {
+    env: { account, region: 'us-east-1' },
+    crossRegionReferences: true,
+  });
+  const mainStack = new MainStack(app, 'MainStack', {
+    env: { account, region: 'us-west-2' },
+    crossRegionReferences: true,
+    signPayloadHandler: virginia.signPayloadHandler,
+    webAclId: virginia.webAclArn,
+  });
+  return { virginia: Template.fromStack(virginia), main: Template.fromStack(mainStack) };
+}
+
+describe('CloudFront flat-rate plan compatibility (issue #187)', () => {
+  test('default behavior uses the managed CACHING_DISABLED policy, not a custom CachePolicy resource', () => {
+    const { main } = synth();
+    // No custom cache policy resource exists (custom policies block Free/Pro enrollment).
+    main.resourceCountIs('AWS::CloudFront::CachePolicy', 0);
+    const defaultBehavior = getDistributionConfig(main).DefaultCacheBehavior as Record<string, unknown>;
+    expect(defaultBehavior.CachePolicyId).toBe(CACHING_DISABLED_ID);
+  });
+
+  test('immutable /_next/static assets are edge-cached via a managed CACHING_OPTIMIZED behavior', () => {
+    const { main } = synth();
+    const behaviors = getDistributionConfig(main).CacheBehaviors as Array<Record<string, unknown>>;
+    const staticBehavior = behaviors.find((b) => b.PathPattern === '/_next/static/*');
+    expect(staticBehavior).toBeDefined();
+    expect(staticBehavior?.CachePolicyId).toBe(CACHING_OPTIMIZED_ID);
+  });
+
+  test('stays within the flat-rate Free plan limit of 5 cache behaviors', () => {
+    const { main } = synth();
+    const additional = (getDistributionConfig(main).CacheBehaviors as unknown[] | undefined)?.length ?? 0;
+    // default behavior (1) + additional behaviors.
+    expect(1 + additional).toBeLessThanOrEqual(5);
+  });
+
+  test('the distribution is associated with the Web ACL', () => {
+    const { main } = synth();
+    expect(getDistributionConfig(main).WebACLId).toBeDefined();
+  });
+});
+
+describe('us-east-1 WAF Web ACL for the flat-rate plan (issue #187)', () => {
+  test('is a Free-plan-compliant CLOUDFRONT-scoped Web ACL without false-positive-prone rules', () => {
+    const { virginia } = synth();
+
+    virginia.resourceCountIs('AWS::WAFv2::WebACL', 1);
+    virginia.hasResourceProperties('AWS::WAFv2::WebACL', { Scope: 'CLOUDFRONT' });
+
+    const webAcls = virginia.findResources('AWS::WAFv2::WebACL');
+    const rules = Object.values(webAcls)[0].Properties.Rules as Array<Record<string, unknown>>;
+    // Free plan allows at most 5 rules.
+    expect(rules.length).toBeLessThanOrEqual(5);
+
+    const serialized = JSON.stringify(rules);
+    // No rules that cause hard-to-diagnose false positives:
+    expect(serialized).not.toContain('rateBasedStatement'); // rate limiting
+    expect(serialized).not.toContain('AmazonIpReputationList'); // IP-reputation blocking
+    expect(serialized).not.toContain('AnonymousIpList'); // blocks Free-plan subscription
+    expect(serialized).not.toContain('CommonRuleSet'); // cookie-size / no-user-agent false positives
+  });
+});

--- a/apps/cdk/test/serverless-fullstack-webapp-starter-kit-without-domain.test.ts
+++ b/apps/cdk/test/serverless-fullstack-webapp-starter-kit-without-domain.test.ts
@@ -24,6 +24,7 @@ test('Snapshot test', () => {
     },
     crossRegionReferences: true,
     signPayloadHandler: virginia.signPayloadHandler,
+    webAclId: virginia.webAclArn,
   });
   const virginiaTemplate = Template.fromStack(virginia);
   const mainTemplate = Template.fromStack(mainStack);

--- a/apps/cdk/test/serverless-fullstack-webapp-starter-kit.test.ts
+++ b/apps/cdk/test/serverless-fullstack-webapp-starter-kit.test.ts
@@ -28,6 +28,7 @@ test('Snapshot test', () => {
     sharedCertificate: virginia.certificate,
     domainName: props.domainName,
     signPayloadHandler: virginia.signPayloadHandler,
+    webAclId: virginia.webAclArn,
   });
   const virginiaTemplate = Template.fromStack(virginia);
   const mainTemplate = Template.fromStack(mainStack);


### PR DESCRIPTION
## Issue

Closes #187
Supersedes #176

## Problem

CloudFront の [flat-rate 料金プラン](https://aws.amazon.com/cloudfront/pricing/)（Free/Pro）は、カスタム cache policy を禁止し、WAF Web ACL の関連付けを必須とする（[Features by pricing plan tier](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/pricing-plans.html)）。キットの共有カスタム `CachePolicy` はこの制約に反するためプラン加入を阻んでいた。さらに同 policy の `allowList` が RSC 関連ヘッダを落とすため、Next.js App Router の RSC ペイロード（`text/x-component`）が通常の HTML キャッシュを汚染しうる（#176）。

## Solution

AWS マネージド cache policy のみを使う構成に変更する:

- **default behavior → `CACHING_DISABLED`**（min/max/default TTL = 0）。CloudFront が動的レスポンスを一切キャッシュしないため、RSC 汚染が原理的に発生せず、Cookie/Authorization を cache key に含める必要もない。リクエストは従来どおり `ALL_VIEWER_EXCEPT_HOST_HEADER` で origin に転送される。これにより #176 / #183（RSC ヘッダを allowList に追加する対処）を構造的な解決で置き換える。
- **`/_next/static/*` → `CACHING_OPTIMIZED`**。immutable かつ content-hash 付きのビルド資産を edge キャッシュし、毎回 Lambda origin に到達しないようにする（Free プラン上限 5 のうち 2 behaviors）。

`us-east-1` に最小構成の WAF Web ACL（scope `CLOUDFRONT`）を作成し distribution に関連付ける。ルールは `KnownBadInputs` のみ。rate-limit / `AmazonIpReputationList` / `CommonRuleSet` は不可解な誤検知（レート/IP レピュテーションによる不透明な 403、大きい Amplify/Cognito 認証 Cookie や User-Agent 欠如でのブロック）の原因になるため除外した。runtime フラグは設けず、copy-and-edit テンプレートの設計原則に従い、WAF が不要なユーザーは Web ACL と `webAclId` の記述を削除する方針とした。

## Changes

- `cf-lambda-furl-service/service.ts`: カスタム `SharedCachePolicy` → マネージド `CACHING_DISABLED`（default）+ `CACHING_OPTIMIZED`（`/_next/static/*`）。任意の `webAclId?` / `geoRestriction?` 関連付けパラメータを追加。
- `us-east-1-stack.ts`: `KnownBadInputs` のみの `CfnWebACL` を生成し、ARN を cross-region で公開。
- `main-stack.ts`, `webapp.ts`, `bin/cdk.ts`: `webAclId` / `geoRestriction` を配線し、Web ACL をデフォルトで関連付け。
- `README.md`: 加入手順をデプロイ手順の step 4 に統合し、⚠️ 警告（加入まで標準 WAF 課金）を追加。Cost セクションの記述を簡潔化。
- `test/cloudfront-free-plan.test.ts`: 新規 assertion。スナップショットを更新。

## Verification

- `pnpm run build` / `pnpm exec jest`（7 tests / 4 snapshots）/ `pnpm run check:ci` — ローカルで全て green。
- 新規 assertion: カスタム `CachePolicy` リソースが存在しないこと + default が CACHING_DISABLED の固定 ID を参照すること、`/_next/static/*` が CACHING_OPTIMIZED であること、cache behavior が 5 以下であること、distribution に `WebACLId` が設定されること、Web ACL が CLOUDFRONT scope で rate-based / `AmazonIpReputationList` / `CommonRuleSet` / `AnonymousIpList` を含まないこと。
- デプロイ自体は 1 コマンド（`cdk deploy --all`）のまま。flat-rate プランへの加入はドキュメント化した手動のコンソール操作。

## Checklist

- [x] I have read [`.starter-kit/DESIGN_PRINCIPLES.md`](https://github.com/aws-samples/serverless-full-stack-webapp-starter-kit/blob/main/.starter-kit/DESIGN_PRINCIPLES.md)
- [x] The diff is minimal — only what the linked issue describes
- [x] One-command deploy is preserved (`pnpm exec cdk deploy --all` remains the only deployment step)
- [x] The type-safety chain (Drizzle → Zod → Server Actions → React) is intact
- [x] Sample data uses fictitious values (AnyCompany, example.com, 192.0.2.0/24, amzn-s3-demo-bucket)
- [x] Lint, build, and tests pass locally (commands in [`AGENTS.md`](https://github.com/aws-samples/serverless-full-stack-webapp-starter-kit/blob/main/AGENTS.md))
