### PR TITLE
fix(cdk): send discriminated-union payload from the scheduled example job

### DIFF
--- a/apps/cdk/lib/constructs/async-job.ts
+++ b/apps/cdk/lib/constructs/async-job.ts
@@ -60,18 +60,27 @@ export class AsyncJob extends Construct {
     new CfnOutput(this, 'HandlerArn', { value: handler.functionArn });
     this.handler = handler;
 
-    // you can add scheduled jobs here.
+    // Example scheduled job — runs on the 1st of every month at 00:00 UTC.
+    // Replace or remove when adding your own scheduled jobs.
     this.addSchedule(
-      'SampleJob',
+      'ExampleJob',
       ScheduleExpression.cron({ minute: '0', hour: '0', day: '1', timeZone: TimeZone.ETC_UTC }),
+      { type: 'example' },
     );
   }
 
-  public addSchedule(jobType: string, schedule: ScheduleExpression, payload?: any) {
-    return new Schedule(this, jobType, {
+  /**
+   * Add an EventBridge Scheduler entry that invokes the async-job Lambda with `payload`.
+   * `payload` must satisfy `jobPayloadPropsSchema` in `@repo/shared-types/job-payload`
+   * (a Zod discriminated union on `type`); the handler parses it at runtime and
+   * dispatches to the matching job. The Schedule construct id (`scheduleId`) becomes
+   * part of the CFN logical id, so choose a stable name.
+   */
+  public addSchedule(scheduleId: string, schedule: ScheduleExpression, payload: Record<string, unknown>) {
+    return new Schedule(this, scheduleId, {
       schedule,
       target: new LambdaInvoke(this.handler, {
-        input: ScheduleTargetInput.fromObject({ jobType, payload }),
+        input: ScheduleTargetInput.fromObject(payload),
         retryAttempts: 5,
       }),
     });

--- a/apps/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit-without-domain.test.ts.snap
+++ b/apps/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit-without-domain.test.ts.snap
@@ -732,6 +732,36 @@ exports[`Snapshot test 2`] = `
       "Type": "AWS::ECR::Repository",
       "UpdateReplacePolicy": "Delete",
     },
+    "AsyncJobExampleJobB709B294": {
+      "Properties": {
+        "FlexibleTimeWindow": {
+          "Mode": "OFF",
+        },
+        "ScheduleExpression": "cron(0 0 1 * ? *)",
+        "ScheduleExpressionTimezone": "Etc/UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": {
+            "Fn::GetAtt": [
+              "AsyncJobHandler438266BD",
+              "Arn",
+            ],
+          },
+          "Input": "{"type":"example"}",
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 5,
+          },
+          "RoleArn": {
+            "Fn::GetAtt": [
+              "SchedulerRoleForTarget44ece2CFC6840F",
+              "Arn",
+            ],
+          },
+        },
+      },
+      "Type": "AWS::Scheduler::Schedule",
+    },
     "AsyncJobHandler438266BD": {
       "DependsOn": [
         "AsyncJobHandlerServiceRoleDefaultPolicy0B2DEDB5",
@@ -947,36 +977,6 @@ exports[`Snapshot test 2`] = `
         ],
       },
       "Type": "AWS::IAM::Role",
-    },
-    "AsyncJobSampleJob3C1EBA2C": {
-      "Properties": {
-        "FlexibleTimeWindow": {
-          "Mode": "OFF",
-        },
-        "ScheduleExpression": "cron(0 0 1 * ? *)",
-        "ScheduleExpressionTimezone": "Etc/UTC",
-        "State": "ENABLED",
-        "Target": {
-          "Arn": {
-            "Fn::GetAtt": [
-              "AsyncJobHandler438266BD",
-              "Arn",
-            ],
-          },
-          "Input": "{"jobType":"SampleJob"}",
-          "RetryPolicy": {
-            "MaximumEventAgeInSeconds": 86400,
-            "MaximumRetryAttempts": 5,
-          },
-          "RoleArn": {
-            "Fn::GetAtt": [
-              "SchedulerRoleForTarget44ece2CFC6840F",
-              "Arn",
-            ],
-          },
-        },
-      },
-      "Type": "AWS::Scheduler::Schedule",
     },
     "AuthBranding34BB87FD": {
       "Properties": {

--- a/apps/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit.test.ts.snap
+++ b/apps/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit.test.ts.snap
@@ -753,6 +753,36 @@ exports[`Snapshot test 2`] = `
       "Type": "AWS::ECR::Repository",
       "UpdateReplacePolicy": "Delete",
     },
+    "AsyncJobExampleJobB709B294": {
+      "Properties": {
+        "FlexibleTimeWindow": {
+          "Mode": "OFF",
+        },
+        "ScheduleExpression": "cron(0 0 1 * ? *)",
+        "ScheduleExpressionTimezone": "Etc/UTC",
+        "State": "ENABLED",
+        "Target": {
+          "Arn": {
+            "Fn::GetAtt": [
+              "AsyncJobHandler438266BD",
+              "Arn",
+            ],
+          },
+          "Input": "{"type":"example"}",
+          "RetryPolicy": {
+            "MaximumEventAgeInSeconds": 86400,
+            "MaximumRetryAttempts": 5,
+          },
+          "RoleArn": {
+            "Fn::GetAtt": [
+              "SchedulerRoleForTarget44ece2CFC6840F",
+              "Arn",
+            ],
+          },
+        },
+      },
+      "Type": "AWS::Scheduler::Schedule",
+    },
     "AsyncJobHandler438266BD": {
       "DependsOn": [
         "AsyncJobHandlerServiceRoleDefaultPolicy0B2DEDB5",
@@ -968,36 +998,6 @@ exports[`Snapshot test 2`] = `
         ],
       },
       "Type": "AWS::IAM::Role",
-    },
-    "AsyncJobSampleJob3C1EBA2C": {
-      "Properties": {
-        "FlexibleTimeWindow": {
-          "Mode": "OFF",
-        },
-        "ScheduleExpression": "cron(0 0 1 * ? *)",
-        "ScheduleExpressionTimezone": "Etc/UTC",
-        "State": "ENABLED",
-        "Target": {
-          "Arn": {
-            "Fn::GetAtt": [
-              "AsyncJobHandler438266BD",
-              "Arn",
-            ],
-          },
-          "Input": "{"jobType":"SampleJob"}",
-          "RetryPolicy": {
-            "MaximumEventAgeInSeconds": 86400,
-            "MaximumRetryAttempts": 5,
-          },
-          "RoleArn": {
-            "Fn::GetAtt": [
-              "SchedulerRoleForTarget44ece2CFC6840F",
-              "Arn",
-            ],
-          },
-        },
-      },
-      "Type": "AWS::Scheduler::Schedule",
     },
     "AuthBranding34BB87FD": {
       "Properties": {


### PR DESCRIPTION
## Issue

Discovered by executor 07 (full-codebase review); tracked in `.kiro/specs/v3-release-prep/99-decisions-log.md` as **E03-3** (a known runtime bug carried forward through executors 03 → 06/07).

## Problem

`AsyncJob.addSchedule` in `apps/cdk/lib/constructs/async-job.ts` wraps the scheduler payload as `{ jobType, payload }`, but the async-job handler (`apps/async-job/src/handler.ts`) parses the raw event against `jobPayloadPropsSchema` — a Zod discriminated union keyed on `type`, defined in `packages/shared-types/src/job-payload.ts`.

The only scheduled job the kit ships (`SampleJob`) therefore fails Zod validation on every fire (every 1st of the month, 00:00 UTC). Because the handler throws on `safeParse` error, EventBridge Scheduler treats each attempt as a failure and retries five times before giving up. A first-time reader of the kit gets a broken scheduler wiring, contradicting the sample's E2E guarantees.

Primary sources:

- Zod discriminated union: <https://zod.dev/api?id=discriminated-unions>
- EventBridge Scheduler input: <https://docs.aws.amazon.com/scheduler/latest/UserGuide/managing-schedule.html>

## Solution

- Rename the sample schedule construct id to `ExampleJob` and pass `{ type: 'example' }` so its payload matches `exampleJobSchema`.
- Change `addSchedule`'s signature so the payload is a discriminated-union member itself (typed as `Record<string, unknown>` in CDK to avoid pulling `zod`/`@repo/shared-types` into the CDK dependency graph; the runtime validation still happens in the handler) and forward it directly via `ScheduleTargetInput.fromObject`.
- Refresh the CDK snapshots to reflect the new Schedule logical id and payload.

Deploy impact: the Schedule construct id changes, so CFN replaces `AsyncJobSampleJob*` with `AsyncJobExampleJob*` on update. The previous schedule only produced failures, so no functional regression.

## Changes

- `apps/cdk/lib/constructs/async-job.ts` — rename to `ExampleJob`, pass `{ type: 'example' }`, tighten `addSchedule` signature and add a JSDoc that points to `jobPayloadPropsSchema`.
- `apps/cdk/test/__snapshots__/*.snap` — updated via `pnpm --filter @repo/cdk run test:unit -u` (2 snapshot files, +30/-30 lines each).

## Verification

- `pnpm --filter @repo/cdk run check:ci` — 0 warnings, 0 errors.
- `pnpm --filter @repo/cdk run build` — `tsc` clean.
- `pnpm --filter @repo/cdk run test:unit` — 3/3 suites, 7/7 tests, 4/4 snapshots pass.
- `pnpm --filter @repo/cdk exec cdk synth` — both stacks synthesize successfully.
- Manually confirmed the new `Input` in the snapshots is `{"type":"example"}`, which is a valid `exampleJobSchema` value; `jobPayloadPropsSchema.safeParse({"type":"example"}).success === true`.

## Checklist

- [x] I have read [`.starter-kit/DESIGN_PRINCIPLES.md`](https://github.com/aws-samples/serverless-full-stack-webapp-starter-kit/blob/main/.starter-kit/DESIGN_PRINCIPLES.md)
- [x] The diff is minimal — only what the linked issue describes
- [x] One-command deploy is preserved (`pnpm exec cdk deploy --all` remains the only deployment step)
- [x] The type-safety chain (Drizzle → Zod → Server Actions → React) is intact
- [x] Sample data uses fictitious values (AnyCompany, example.com, 192.0.2.0/24, amzn-s3-demo-bucket)
- [x] Lint, build, and tests pass locally (commands in [`AGENTS.md`](https://github.com/aws-samples/serverless-full-stack-webapp-starter-kit/blob/main/AGENTS.md))
