### PR TITLE
fix(cdk): use RFC 5737 documentation IP for Cognito parent A record

### DIFF
--- a/apps/cdk/lib/us-east-1-stack.ts
+++ b/apps/cdk/lib/us-east-1-stack.ts
@@ -44,7 +44,12 @@ export class UsEast1Stack extends cdk.Stack {
       // > Its parent domain must have a valid DNS A record. You can assign any value to this record.
       new ARecord(this, 'Record', {
         zone: hostedZone,
-        target: RecordTarget.fromIpAddresses('8.8.8.8'),
+        // Cognito custom domain requires the parent zone to have a valid A record — the
+        // value itself is not resolved during OAuth. Use TEST-NET-1 (RFC 5737), the
+        // documentation range for sample values, so this record cannot accidentally
+        // point real traffic at any live host.
+        // https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-add-custom-domain.html#cognito-user-pools-add-custom-domain-adding
+        target: RecordTarget.fromIpAddresses('192.0.2.1'),
       });
 
       const cert = new Certificate(this, 'CertificateV2', {

--- a/apps/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit.test.ts.snap
+++ b/apps/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit.test.ts.snap
@@ -144,7 +144,7 @@ exports[`Snapshot test 1`] = `
         "HostedZoneId": "DUMMY",
         "Name": "example.com.",
         "ResourceRecords": [
-          "8.8.8.8",
+          "192.0.2.1",
         ],
         "TTL": "1800",
         "Type": "A",


### PR DESCRIPTION
## Issue

Discovered by executor 07 (full-codebase review), corroborated by an independent security review (subagent, opus-4.7). No pre-existing tracker issue.

## Problem

`apps/cdk/lib/us-east-1-stack.ts` (custom-domain branch) creates an apex A record pointing at `8.8.8.8` (Google Public DNS). The record only exists to satisfy Cognito's custom-domain requirement that the parent zone hold a valid A record — Cognito never queries the value — but hard-coding a live third-party address violates two of the kit's rules:

1. `.starter-kit/DESIGN_PRINCIPLES.md` and the PR template both require sample data to use approved fictitious values (`AnyCompany`, `example.com`, `192.0.2.0/24`, `amzn-s3-demo-bucket`).
2. When the kit is copied into a real repo and deployed with a real hosted zone, the record replaces the operator's apex traffic target with a third-party IP, breaking apex traffic for the copied app.

Primary sources:

- Cognito custom-domain parent A record requirement: <https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-add-custom-domain.html#cognito-user-pools-add-custom-domain-adding>
- RFC 5737 (documentation IPv4 ranges — TEST-NET-1 `192.0.2.0/24`): <https://datatracker.ietf.org/doc/html/rfc5737>

## Solution

Replace the address with `192.0.2.1` (TEST-NET-1, the RFC 5737 reserved documentation range — an unroutable address that cannot resolve to any real host), and add an inline comment that names the requirement and links to the Cognito doc so the next reader does not need to rediscover why the record exists.

## Changes

- `apps/cdk/lib/us-east-1-stack.ts` — swap `8.8.8.8` for `192.0.2.1` and inline the Cognito requirement + rationale as a code comment.
- `apps/cdk/test/__snapshots__/serverless-fullstack-webapp-starter-kit.test.ts.snap` — reflect the new record value (the without-domain snapshot is unchanged because that path does not create the record).

## Verification

- `pnpm --filter @repo/cdk run check:ci` — 0 warnings, 0 errors.
- `pnpm --filter @repo/cdk run build` — `tsc` clean.
- `pnpm --filter @repo/cdk run test:unit` — 3/3 suites, 7/7 tests, 4/4 snapshots pass.
- `pnpm --filter @repo/cdk exec cdk synth` — both stacks synthesize successfully.

## Checklist

- [x] I have read [`.starter-kit/DESIGN_PRINCIPLES.md`](https://github.com/aws-samples/serverless-full-stack-webapp-starter-kit/blob/main/.starter-kit/DESIGN_PRINCIPLES.md)
- [x] The diff is minimal — only what the linked issue describes
- [x] One-command deploy is preserved (`pnpm exec cdk deploy --all` remains the only deployment step)
- [x] The type-safety chain (Drizzle → Zod → Server Actions → React) is intact
- [x] Sample data uses fictitious values (AnyCompany, example.com, 192.0.2.0/24, amzn-s3-demo-bucket)
- [x] Lint, build, and tests pass locally (commands in [`AGENTS.md`](https://github.com/aws-samples/serverless-full-stack-webapp-starter-kit/blob/main/AGENTS.md))
