### PR TITLE
fix(cdk): use Cognito sub for AppSync event-bus channel authorization

### DIFF
--- a/apps/cdk/lib/constructs/event-bus/handler.mjs
+++ b/apps/cdk/lib/constructs/event-bus/handler.mjs
@@ -10,9 +10,9 @@ export function onSubscribe(ctx) {
   if (ctx.info.channel.path.startsWith(`/event-bus/public`)) {
     return;
   }
-  if (ctx.info.channel.path.startsWith(`/event-bus/user/${ctx.identity.username}`)) {
+  if (ctx.info.channel.path.startsWith(`/event-bus/user/${ctx.identity.sub}`)) {
     return;
   }
-  console.log(`user ${ctx.identity.username} tried connecting to wrong channel: ${ctx.channel}`);
+  console.log(`user sub ${ctx.identity.sub} tried connecting to wrong channel: ${ctx.channel}`);
   util.unauthorized();
 }


### PR DESCRIPTION
## Summary

Aligns the AppSync Events subscribe authorizer with the `sub` claim, which the webapp already uses to construct the channel path (`session.userSub` in `apps/webapp/src/lib/auth.ts:47`).

**Change** (2 lines): `apps/cdk/lib/constructs/event-bus/handler.mjs` — `ctx.identity.username` → `ctx.identity.sub` and the accompanying log message.

## Rationale

The authorizer previously compared `ctx.identity.username` against a channel path built from `sub`. In the current pool configuration (`UsernameAttributes: ['email']`), Cognito assigns a UUID as the internal username that happens to equal `sub` — see the [AppSync Events context reference](https://docs.aws.amazon.com/appsync/latest/eventapi/context-reference.html) (`AMAZON_COGNITO_USER_POOLS`: `username` = the `cognito:username` claim; `sub` = the UUID of the authenticated user). The equivalence between `cognito:username` and `sub` is a Cognito internal behavior for email/phone alias configurations, not a documented API contract; it breaks silently if `signInAliases` is changed. Aligning on `sub` removes the dependency on that internal equivalence and matches the widely cited guidance to prefer `sub` for user identity because username values can be reassigned.

## Relation to other v3 review work

- **E03-3 / F-CDK-02 / F-JOB-01 (SampleJob payload)** — a duplicate commit was in this PR earlier; dropped after force-push because [PR #207](https://github.com/aws-samples/serverless-full-stack-webapp-starter-kit/pull/207) (from executor 07) already fixes the same bug with a more informative construct name and doc comment. Keeping the SampleJob fix in a single PR preserves the "one PR = one release-notes entry" rule (D6/O3).
- **Issue [#216](https://github.com/aws-samples/serverless-full-stack-webapp-starter-kit/issues/216)** — executor 07 filed a broader security concern combining (a) unbounded `startsWith` prefix collision and (b) the username/sub attribute mixup addressed here. This PR closes the sub/username part; the delimiter-anchor part remains open under #216.

## Verification

Full CI green before force-push (see run [88823726687](https://github.com/aws-samples/serverless-full-stack-webapp-starter-kit/actions/runs/29888401024/job/88823726687) — `Build-and-Test` pass 1m7s, `lint` pass 3s). The dropped SampleJob commit's snapshot delta is now removed from this PR; the remaining diff is `.mjs`-only, so no snapshots regenerate.

## Discovered by

Executor 06 (v3 diff review), finding F-CDK-01. See `.kiro/specs/v3-release-prep/review-diff-report.md` for full context.