### PR TITLE
docs: add English versions of v3.0.0 docs (bilingualization)

### DIFF
--- a/.starter-kit/DESIGN_PRINCIPLES.md
+++ b/.starter-kit/DESIGN_PRINCIPLES.md
@@ -85,7 +85,7 @@ To surface the migration guide in release notes, include a link in the `BREAKING
 ```
 feat!: replace ORM from Prisma to Drizzle
 
-BREAKING CHANGE: ORM has been replaced. See [migration guide](docs/v3.0.0/migration-prompt.ja.md) for details.
+BREAKING CHANGE: ORM has been replaced. See [migration guide](docs/v3.0.0/migration-prompt.md) for details.
 ```
 
 release-please will carry this into the Breaking Changes section of the GitHub Release.

--- a/.starter-kit/docs/v3.0.0/adr-001-dsql-drizzle-migrator.md
+++ b/.starter-kit/docs/v3.0.0/adr-001-dsql-drizzle-migrator.md
@@ -1,0 +1,76 @@
+# ADR-001: Aurora DSQL + Drizzle ORM + custom migration runner
+
+## Status
+
+Accepted (v3.0.0)
+
+## Context
+
+The v2 architecture had three intertwined problems:
+
+1. **VPC cost and Aurora Serverless v2 operational issues**: Aurora Serverless v2 requires a VPC + NAT for Lambda access. In addition to the operational cost of a VPC including a NAT Instance (t4g.nano, ~$3/month) and Bastion Host, it has operational overhead such as security groups, subnets, and waiting for Hyperplane ENI attach/detach when updating Lambda functions. Aurora Serverless v2 also did not fit the kit's use case: even with auto-pause (0 ACU) configured, a cold start after sleeping for 24 hours or more takes 20–30 seconds and degrades the user experience; scheduled jobs every five minutes keep it effectively always running, preventing it from benefiting from auto-pause; and retry and error handling for connection errors requires considerable development effort. It did not fit the kit's concept of "minimizing infrastructure costs while enabling rapid prototype development."
+2. **Prisma binary overhead**: `prisma generate` generates platform-specific query-engine binaries. In a monorepo, every package that imports the Prisma Client requires generate. The binaries inflate Docker images and complicate cross-platform builds.
+3. **Single `package.json` for unrelated components**: Next.js, asynchronous jobs, and the migration runner coexist in `webapp/`. Although `job.Dockerfile` was separate, the single `package.json` caused `npm ci` to install all webapp dependencies (React, Next.js, aws-amplify, etc.), inflating the image. Properly separating `dependencies`/`devDependencies` with esbuild tree-shaking could reduce the final image, but the temporary installation of all dependencies during builds and the cognitive load of this build method were problems. Extracting shared DB code into a monorepo package also required resolving Prisma's binary-sharing problem at the same time.
+
+These three problems form a dependency chain: resolving the monorepo structure requires resolving Prisma sharing, the highest-impact improvement (eliminating VPC costs) requires changing the DB engine, and that in turn changes the ORM choice. Solving all three simultaneously avoids intermediate waste.
+
+## Decision
+
+**Database: Aurora DSQL** — A serverless distributed SQL database that does not require a VPC. Lambda connects with IAM authentication over the public internet. True pay-per-use billing (read/write RPUs) also results in zero cost when there is no traffic.
+
+**ORM: Drizzle ORM** — A pure TypeScript ORM with no code generation step. Reasons for the choice:
+
+1. Neither `prisma generate` nor platform-specific binaries are required. Schema definitions are ordinary TypeScript files and can be imported between packages in the monorepo without a build step.
+2. `relations()` defines query-builder relations without generating SQL-level foreign keys, naturally fitting DSQL's no-FK constraint.
+3. Prisma 7 is undergoing an architectural migration from Rust to TypeScript, and performance degradation for highly concurrent small queries has been reported. This avoids that risk.
+
+Official Drizzle support for Aurora DSQL is not yet released (drizzle-team/drizzle-orm#5248), but it works through node-postgres.
+
+**Migration runner: custom implementation** — The migration tools built into drizzle-kit are incompatible with DSQL:
+
+- `drizzle-kit migrate`: Its internal implementation (dialect.ts) runs all unapplied migrations together in a single transaction. This fundamentally conflicts with DSQL's 1 DDL per transaction constraint. In addition, it uses `SERIAL PRIMARY KEY` to create its management table, which DSQL also does not support.
+- `drizzle-kit push`: Runs DDL directly without accounting for DSQL constraints.
+
+Following "Option 5" in the official Drizzle documentation (generate SQL with drizzle-kit and apply it with an external tool), adopt the same approach as Vercel's aws-dsql-movies-demo. For portability, the runner has a three-layer architecture (core logic / Lambda handler / CDK Construct). The CDK Construct automatically runs migrations with a deploy-time Trigger and guarantees change detection and re-execution through a content hash of `migrations/` (see C1 under "Consequences" below). See the [design doc](design.md#custom-migration-runner) for implementation specifications.
+
+### Rejected alternatives
+
+**Database:**
+
+- _Aurora Serverless v2 (retain)_: VPC costs, cold starts, and the always-running issue caused by scheduled jobs remain. The development cost of retry handling for connection errors also remains unresolved.
+- _DynamoDB_: Requires exhaustive advance coverage of access patterns for table design. Compared with the query flexibility provided by SQL in Aurora Serverless v2, it was determined to offer no advantage as a starter kit.
+
+**ORM:**
+
+- _Prisma + aurora-dsql-prisma-tools_: Requires `prisma generate`, leaving the binary overhead. `@relation` assumes FK support, requiring aurora-dsql-prisma-tools to remove FK statements from generated SQL. Prisma 7's Rust → TypeScript architectural migration creates further uncertainty.
+- _Kysely_: A pure TypeScript query builder, but it lacks declarative relation definitions like Drizzle's `relations()`. Joins must be constructed manually.
+- _Raw SQL_: Lacks type safety. This conflicts with the kit's goal of end-to-end type safety from the DB to React components.
+
+**Migration runner:**
+
+- _drizzle-kit migrate_: Runs all migrations in one transaction — fundamentally incompatible with DSQL's 1 DDL per transaction constraint.
+- _drizzle-kit push_: Ignores DSQL constraints.
+- _Flyway_: Has a JVM dependency. It adds operational complexity to a Node.js/TypeScript project. (It added DSQL dialect support in February 2026, but the JVM requirement remains.)
+
+## Consequences
+
+- **Impact of DDL constraints**: DSQL constraints affect schema design, lint rules, and migration tools. Major constraints: no FK, no SERIAL, 1 DDL per transaction, `CREATE INDEX ASYNC` required, and ALTER TABLE supports only ADD COLUMN, RENAME, IDENTITY operations, OWNER TO, and SET SCHEMA (DROP COLUMN, ALTER COLUMN TYPE, SET/DROP NOT NULL, SET/DROP DEFAULT, and DROP CONSTRAINT are not allowed. ADD COLUMN also cannot include DEFAULT/NOT NULL/CHECK/UNIQUE/PRIMARY KEY — add it as nullable and backfill with UPDATE). Note that `json`/`jsonb` were initially unsupported, but are now available because DSQL added support in 2026 (automatically compressed, but not indexable. See AGENTS.md / README for details). A two-layer detection strategy is required (oxlint for schema definitions and SQL validation for generated migrations; the latter also detects ADD COLUMN constraints and missing `ASYNC`). See the [design doc](design.md#ddl-constraints) for the complete list of DDL constraints.
+- **Migration runner maintenance**: The custom runner is additional code to maintain. However, its core logic is approximately 200 lines and has comprehensive tests (unit + integration).
+- **Drizzle DSQL support gap**: Drizzle does not yet officially support Aurora DSQL (drizzle-team/drizzle-orm#5248). drizzle-kit generate does not account for DSQL constraints — its output requires automatic transformation (`CREATE INDEX` → `CREATE INDEX ASYNC`, FK removal) and validation. A two-layer compatibility check is introduced to mitigate this risk.
+- **Table recreation for schema changes**: Due to DSQL's limited ALTER TABLE support, many schema changes require table recreation with data migration. The runner supports `.sql` and `.mjs` migration files for batch data operations (`.ts` is unsupported — because the same file runs untransformed locally and in Lambda. See [ADR-005](adr-005-migration-file-format.md) for details).
+- **Migration state management**: The `_migrations` table tracks only name (full file name) + executed_at. **Tamper detection using content hashes** for applied files was rejected. When a formatter or editor formats an applied file, its byte sequence changes and causes a hash mismatch error even if the logic has not changed. Git management sufficiently prevents tampering with applied files. This is a separate mechanism with a different purpose from the `migrations/` directory hash for deploy-time re-execution (C1 below).
+- **Guarantee of migration re-execution at deploy time (C1)**: Because the CDK Construct creates an image with `ContainerImageBuild` (deploy-time build), the image content hash is not determined at synth time, and standard CDK/CloudFormation change detection cannot capture migration changes. As a countermeasure, the migrator Construct calculates a content hash of the entire `migrations/` directory and (1) invalidates the published Lambda version with `invalidateVersionBasedOn`, and (2) injects it into the CDK Trigger's `Custom::Trigger` properties. This guarantees "migration change → new version published → Trigger re-executes the latest version." The hash scope is a superset of the runner's target (`.sql`/`.mjs`): the entire directory. This structurally eliminates silent skips caused by file formats that are not hashed. An approach to share an extension list by importing it from `packages/db` was not adopted because `require()` becomes `ERR_REQUIRE_ESM` at the boundary between `packages/db` (ESM) and CDK (ts-node CommonJS); hashing the entire directory replaces it.
+- **Error recovery strategy**: Do not automatically roll back on `check-dsql-compat` errors. To avoid depending on drizzle-kit's internal format (snapshot JSON), the user explicitly reverts with `git checkout -- migrations/`.
+
+### Differences from the Vercel demo (aws-dsql-movies-demo)
+
+| Feature                      | Vercel demo                          | This migrator                                                                                                               |
+| ---------------------------- | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------- |
+| Management table             | `migrations` (id, name, executed_at) | `_migrations` (name, executed_at)                                                                                           |
+| Hash verification            | None                                 | Content-hash tamper detection is not adopted (a migrations/ directory hash is used separately for deploy-time re-execution) |
+| drizzle-kit generate         | Not used (handwritten SQL)           | Used (output is automatically transformed)                                                                                  |
+| Automatic SQL transformation | None                                 | statement-breakpoint → blank lines, INDEX → ASYNC, FK removal                                                               |
+| SQL validation               | None                                 | Detects ALTER COLUMN TYPE, DROP COLUMN, etc.                                                                                |
+| Execution environment        | CLI only                             | CLI + Lambda (CDK Trigger)                                                                                                  |
+| Connection method            | Vercel OIDC                          | IAM authentication (Lambda execution role / AWS profile)                                                                    |
+| `already exists` skip        | Yes                                  | Yes                                                                                                                         |

--- a/.starter-kit/docs/v3.0.0/adr-002-pnpm-workspaces.md
+++ b/.starter-kit/docs/v3.0.0/adr-002-pnpm-workspaces.md
@@ -1,0 +1,34 @@
+# ADR-002: pnpm workspaces monorepo
+
+## Status
+
+Accepted (v3.0.0)
+
+## Context
+
+In v2, Next.js, asynchronous jobs, and the migration runner coexist in a single package under `webapp/`. Although `job.Dockerfile` is separate, there is only one `package.json`, so `npm ci` installs all webapp dependencies (React, Next.js, aws-amplify, etc.), increasing image size and build time.
+
+A monorepo tool is required to extract asynchronous jobs and DB code into separate packages. The choice of package manager also affects Docker build behavior, dependency resolution strictness, and CI performance.
+
+## Decision
+
+Use pnpm workspaces in strict mode (without `shamefully-hoist`).
+
+```
+apps/           # deployable applications (webapp, async-job, cdk)
+packages/       # shared libraries (db, shared-types)
+```
+
+Internal packages use the `@repo/` scope. Applications do not depend on each other.
+
+### Rejected alternatives
+
+- _npm workspaces_: A flat `node_modules` implicitly resolves undeclared dependencies and hides undeclared dependencies that break in Docker builds. pnpm strict mode detects these during installation.
+- _Turborepo + pnpm_: It adds task orchestration and caching, but the kit has only five packages and a simple dependency chain. At this scale, Turborepo configuration overhead is not justified. Users can add it later if needed.
+
+## Consequences
+
+- **Docker `--filter` limitation**: In strict mode, `pnpm install --filter` does not hoist transitive dependencies of workspace packages. Dockerfiles must install all workspace dependencies with `pnpm install --frozen-lockfile` without `--filter`.
+- **`.dockerignore` + `ignoreMode`**: CDK's `DockerImageCode.fromImageAsset` does not read `.dockerignore` by default. `ignoreMode: IgnoreMode.DOCKER` is required for all Docker assets to prevent recursive copying of `cdk.out` (`ENAMETOOLONG`).
+- **ESM + Lambda**: Output from esbuild `--format=esm` requires the `.mjs` extension in Lambda. The Node.js runtime loads it as CommonJS unless it has `.mjs` or `"type": "module"` in `package.json`.
+- **`@aws/*` ≠ `@aws-sdk/*`**: `--external:@aws-sdk/*` does not exclude `@aws/aurora-dsql-node-postgres-connector`. The Lambda runtime provides only `@aws-sdk/*`. Other `@aws/*` packages must be bundled.

--- a/.starter-kit/docs/v3.0.0/adr-003-oxlint-oxfmt.md
+++ b/.starter-kit/docs/v3.0.0/adr-003-oxlint-oxfmt.md
@@ -1,0 +1,30 @@
+# ADR-003: oxlint + oxfmt
+
+## Status
+
+Accepted (v3.0.0)
+
+## Context
+
+The kit needs lint rules that detect DSQL-incompatible patterns during coding — specifically, `no-restricted-imports`, which blocks imports of `serial` / `smallserial` / `bigserial` from `drizzle-orm/pg-core`.
+
+The kit also assumes use with AI coding agents and recommends a post-write hook that runs lint + format after every file write (see the README "Agentic coding" section). In this workflow, it is essential that the linter and formatter run quickly enough to be imperceptible in an editor workflow.
+
+## Decision
+
+Replace ESLint + Prettier with oxlint + oxfmt. oxlint runs the required `no-restricted-imports` rule substantially faster than ESLint (Rust-based). oxfmt is an alternative to Prettier.
+
+Configured DSQL-specific rules:
+
+- `no-restricted-imports`: blocks `serial`, `smallserial`, `bigserial` from `drizzle-orm/pg-core`
+- `no-restricted-syntax`: blocks `.references()` calls in schema files (configured but non-functional — see Consequences)
+
+### Rejected alternatives
+
+- _ESLint + Prettier (retain)_: Execution is slow. The ESLint ecosystem is large, but the kit needs only a small subset of rules. The speed difference is perceptible in CI and editor feedback.
+- _Biome_: A Rust-based linter + formatter (single tool). However, Biome does not support `no-restricted-imports` with the required granularity (blocking a specific named import from a module). oxlint's implementation matches ESLint rule semantics.
+
+## Consequences
+
+- **`no-restricted-syntax` unsupported**: As of oxlint v1.56.0, `no-restricted-syntax` is unimplemented. The `.references()` call restriction is configured in `oxlintrc.json` but inactive. It is automatically enabled when oxlint adds support. Until then, SQL-level validation in `check-dsql-compat.ts` (detecting `REFERENCES`/`FOREIGN KEY` in generated SQL) is the fallback.
+- **Smaller rule ecosystem**: oxlint supports fewer rules than ESLint. Coverage is sufficient for the kit's needs (Next.js plugin, TypeScript, import restrictions). Users who need additional ESLint rules can add ESLint alongside oxlint.

--- a/.starter-kit/docs/v3.0.0/adr-004-dsql-admin-role.md
+++ b/.starter-kit/docs/v3.0.0/adr-004-dsql-admin-role.md
@@ -1,0 +1,62 @@
+# ADR-004: Retaining the DSQL admin role
+
+## Status
+
+Accepted (v3.0.0)
+
+## Context
+
+Aurora DSQL provides two types of database roles:
+
+- **admin role**: Connects with the IAM action `dsql:DbConnectAdmin`. It has all privileges for DDL + DML + role management. It is the only built-in role, automatically created when the cluster is created.
+- **custom role**: Connects with the IAM action `dsql:DbConnect`. Create it with `admin` using `CREATE ROLE ... WITH LOGIN` → `AWS IAM GRANT <role> TO '<IAM ARN>'` → `GRANT ... ON ALL TABLES IN SCHEMA`. It can perform only the granted DML privileges.
+
+`@aws/aurora-dsql-node-postgres-connector` determines the token type from the `user` parameter at connection time:
+
+```js
+if (user === "admin") token = await signer.getDbConnectAdminAuthToken();
+else token = await signer.getDbConnectAuthToken();
+```
+
+Currently, all Lambda functions (webapp, async-job, migrator) connect with `user: 'admin'` + `dsql:DbConnectAdmin`. Following the principle of least privilege, runtime functions (webapp, async-job) should be separated into a custom role with DML privileges only.
+
+In v2 (Aurora Serverless v2), all Lambda functions also connected with the primary user (`admin`). In v2, the password from Secrets Manager was passed to Lambda environment variables, so the v3 IAM temporary token approach improves the authentication layer.
+
+### Security risks of the admin role
+
+In addition to DML, the admin role can perform DDL (`CREATE/DROP/ALTER TABLE`, `CREATE/DROP INDEX`) and role management (`CREATE ROLE`, `AWS IAM GRANT`). If DDL is executed through an application vulnerability (such as SQL injection), it can cause data loss by dropping tables or grant database access to arbitrary IAM roles.
+
+With a custom role, the impact is limited to granted DML operations (reading, modifying, and deleting data).
+
+In this kit, Drizzle ORM parameterizes queries, so SQL injection requires bypassing ORM parameterization and the practical risk is low. However, from a defense in depth perspective, custom role separation is an effective additional layer of protection.
+
+### Work required to introduce custom roles
+
+Custom roles can be introduced with the following steps:
+
+1. In a migration, run `CREATE ROLE app WITH LOGIN` + `AWS IAM GRANT app TO '<Lambda execution role ARN>'`
+2. After the migration, run `GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO app` (`ON ALL TABLES` grants privileges to all existing tables at once)
+3. Change `user: 'admin'` in `client.ts` to `user: 'app'`
+4. Change the CDK IAM policy from `dsql:DbConnectAdmin` → `dsql:DbConnect`
+
+`GRANT ... ON ALL TABLES IN SCHEMA` grants privileges on all existing tables at once, so individual GRANTs for each table are unnecessary. However, because DSQL does [not support](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/working-with-postgresql-compatibility-supported-sql-features.html) `ALTER DEFAULT PRIVILEGES`, GRANTs must be run again with every migration that adds tables (this can be automated by adding one line at the end of the migration runner).
+
+## Decision
+
+In v3.0.0, retain the `admin` role for all Lambda functions.
+
+The primary reasons for deferring separation into custom roles are:
+
+1. **Ordering dependency between CDK and migrations**: A custom role's `AWS IAM GRANT` requires the Lambda execution role ARN. This creates an ordering dependency: create the role in CDK → create the IAM mapping in a migration. This complicates the bootstrap for the initial deployment.
+2. **Continuation from v2**: In v2, all connections also used the primary user, and moving to IAM temporary tokens in v3 has already improved the authentication layer. Role separation is an additional improvement and has lower priority for the v3 scope.
+
+### Rejected alternatives
+
+- _Custom role separation_: Although `ON ALL TABLES` simplifies GRANT management, the ordering dependency between CDK and migrations does not fit the starter kit's "copy and grow" concept. Consider introducing it when growing into a production product.
+- _Only the migrator uses admin; runtime functions use a custom role_: The IAM mapping bootstrap issue remains the same even with partial separation.
+
+## Consequences
+
+- The webapp and async-job Lambda functions have privileges to execute DDL. There is a risk that schema changes or role operations could be executed through vulnerabilities such as SQL injection (the practical risk is low because Drizzle ORM parameterizes queries).
+- For production workloads, recommend moving to the principle of least privilege using [DSQL custom database roles](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/using-database-and-iam-roles.html). See "Work required to introduce custom roles" above.
+- CDK's `Database.grantConnect()` method is designed to allow a future split into `grantConnect` (DML) / `grantConnectAdmin` (DDL) in preparation for separation.

--- a/.starter-kit/docs/v3.0.0/adr-005-migration-file-format.md
+++ b/.starter-kit/docs/v3.0.0/adr-005-migration-file-format.md
@@ -1,0 +1,116 @@
+# ADR-005: Unifying Migration File Formats (Removing `.ts`; `.sql` + `.mjs`)
+
+## Status
+
+Accepted (v3.0.0). This supersedes the decision in ADR-001, “Aurora DSQL + Drizzle ORM + Custom Migration Runner,”
+to “support `.ts` migration files for batch data operations.”
+
+## Context
+
+The initial v3 migration runner accepted three formats under `migrations/`: `.sql` / `.ts` / `.mjs`,
+and batch data migrations (table recreation and backfills exceeding 3,000 rows) could be written in `.ts`.
+
+This design had structural flaws:
+
+1. **The executed files diverge between local and Lambda.** The runner was intended to execute `.ts` with `tsx` in
+   local development and `.mjs` in Lambda (Docker, Node runtime). The README also stated that “in Lambda, `.ts` is
+   pre-transpiled to `.mjs` in the Dockerfile,” but the actual migrator Dockerfile only copies `migrations/` as-is and
+   has no transpile step, so the documentation and implementation diverged. As a result, `.ts` migrations raise a
+   SyntaxError when the Lambda Node runtime calls `import()`.
+
+2. **The same migration can coexist in two formats.** This creates conditions for double execution. In a downstream
+   repository after several months of production use, mechanisms were introduced to address this divergence: “remove
+   extensions from the duplicate-execution prevention key in the `_migrations` ledger (`WHERE name = $1 OR name = $2`)”
+   and “convert `.ts`→`.mjs` during the Docker build and remove `.ts`.” These are legitimate costs to make `.ts` work,
+   but they are unnecessary complexity for the `.sql` that most kit users write and the small number of `.mjs` files.
+
+The root cause is that “the same migration can exist in two formats: `.ts` (local) and `.mjs` (Lambda).”
+In the default runner, a committed file should be executed **identically in both** local and Lambda,
+without a transpile step. However, for users whose migrations become large-scale and multi-file, where type-safe
+implementations substantially reduce risk, `.ts` is not prohibited; it is positioned as the escape hatch described below.
+
+## Decision
+
+**Limit the default canonical formats in `migrations/` to two: `.sql` (schema changes) and `.mjs` (batch data migrations).**
+The default runner does not handle `.ts` (see the “Escape Hatch” section for when complexity exceeds `.mjs`).
+
+- Align the runner's target extensions, the CDK migrator's migration content hash, and Docker packaging with
+  `.sql`/`.mjs`. Do not include a transpile step (Docker raw copies `migrations/` and executes `.mjs` as-is).
+- `.mjs` can be imported with `import()` unchanged by either `node` or `tsx`, so local and Lambda execute the same file.
+  Provide type completion with JSDoc (`/** @param {import('pg').PoolClient} client */`).
+- **The `.mjs` interface is `export default async function(client, context)`.** The second argument, `context`
+  (`MigrationContext`), is an injection seam for data migrations that access AWS resources, such as taking an S3
+  backup before a breaking change. It is empty by default, and the sample app requires nothing. To provide resources,
+  add fields to `MigrationContext`, populate their values in `migrate-cli.ts` (local) and the migrator handler (Lambda),
+  and grant the corresponding IAM permissions in the `DsqlMigrator` construct. A migration that does not use `context`
+  may ignore the second argument (`function(client)` remains valid).
+- The runner applies `transformSql` to `.sql` at runtime as well (defense in depth for hand-written SQL that does not go
+  through `generate`).
+
+## Escape Hatch: Adopting `.ts` When `.mjs` Is Not Enough
+
+When a migration becomes large-scale, multi-file, or verification-focused (for example, dumping all tables to S3 and
+verifying them with SHA-256 before conversion ahead of a breaking rename) and JSDoc-equipped `.mjs` files no longer
+provide sufficient type safety or maintainability, adopting `.ts` is not an anti-pattern but a legitimate choice.
+The recommended form in that case is as follows:
+
+- **Use `.ts` as the single committed source.** Commit only one `migrations/NNNN_x.ts`, transpile it to `.mjs` with
+  esbuild during the Docker build, and remove `.ts` from the image (Lambda executes only `.mjs`). Locally, `tsx` executes
+  `.ts` directly. Place specific logic that you want to split into multiple files under `migrations/NNNN_x/`, import it
+  relatively from the entrypoint, and inline it into the parent `.mjs` with `--bundle`.
+- **Make the `_migrations` ledger key extension-agnostic.** Because the format divergence remains—`.ts` locally and
+  `.mjs` in Lambda—remove extensions from the ledger's duplicate-detection key to prevent double execution of the same
+  migration (`file.replace(/\.(sql|ts|mjs)$/, '')`). Also include `.ts` in the runner's target extensions and the CDK
+  migrator's hash targets.
+- **Constrain imports out of `migrations/`.** Prohibit relative imports that leave `migrations/`. Also disallow value
+  imports from `@repo/**`, `drizzle-orm`, and `pg` in migration files (they cannot be resolved in the Lambda runtime).
+  It is advisable to mechanically check these boundaries with lint.
+
+Introduce this only when deciding to accept these costs (format divergence + extension-removal key + import boundary).
+They are not built into the default runner from the start because doing so would permanently impose unnecessary complexity
+on most users (`.sql`-centric with rare `.mjs`).
+
+### Rejected alternatives
+
+- **Transpile `.ts` and commit both the generated `.mjs` (authoring-only approach):** The runtime format becomes only
+  `.mjs`, but two committed files, `.ts` (source) and `.mjs` (generated artifact), coexist, creating a substantial risk
+  that they diverge through manual edits or similar changes. Prefer the single-source escape hatch above (commit only
+  `.ts`).
+- **Execute `.ts` in Lambda without conversion** (bundle `tsx` in the image / use Node's `--experimental-strip-types`):
+  The former adds runtime dependencies and loader registration, and also bloats the image. The latter depends on an
+  experimental flag, creating risks from Node minor-version differences and warning output. Both conflict with the kit's
+  emphasis on reproducibility as a “copy and grow” kit.
+
+## Consequences
+
+- **There is no impact on `.sql` migrations or existing `.mjs` users.** Most migrations are `.sql` generated by
+  drizzle-kit, and `.mjs` is limited to rare batch data migrations, so the impact is limited.
+- The **default runner** has no format divergence, and the `_migrations` ledger key remains the full file name without
+  ambiguity (1 migration = 1 file, 1 extension). A duplicate-execution prevention key based on extension removal is
+  unnecessary unless `.ts` is introduced through the escape hatch.
+- **The `context` injection seam allows data migrations that require AWS resources, such as external backups before
+  breaking changes, to be implemented as `.mjs` without changing the file format.** Migration safety (format-independent
+  idempotency, verification before swap, and external backups) is provided by this seam and how each migration is
+  written, not by the file format.
+- Documentation (`packages/db/README.md`, `AGENTS.md`) and the implementation (the fact that the Dockerfile raw copies)
+  are aligned.
+
+### Breaking change: Migration Steps for Existing v3 Users
+
+If you already wrote batch data migrations in `.ts`, the following migration is required:
+
+1. Rename `migrations/NNNN_x.ts` to `migrations/NNNN_x.mjs`.
+2. Replace TypeScript type annotations with JSDoc (keep the form `export default async function(client)`.
+   `import type { PoolClient }` is unnecessary; use `/** @param {import('pg').PoolClient} client */`).
+3. If the migration is **not yet applied**, this completes the migration.
+4. If the migration is **already applied**, care is required. The `_migrations` table records the old name, `NNNN_x.ts`.
+   Because the runner determines whether to skip using the full file name, the renamed `NNNN_x.mjs` is
+   **considered unapplied and is executed again**. To avoid double application of a data migration, before deployment,
+   do one of the following in each environment:
+   - Update the ledger name: `UPDATE _migrations SET name = 'NNNN_x.mjs' WHERE name = 'NNNN_x.ts';`
+   - Alternatively, rewrite the migration to be idempotent, so it is safe to run again.
+
+Because this kit follows a copy-and-grow model and has a limited number of early users, the extension-agnostic
+backward-compatible key (adopted by the downstream app) is not introduced into the runner; the explicit migration
+steps above are adopted instead. This prioritizes keeping the runner simple and the clarity of `_migrations` semantics
+(the recorded file name = applied).

--- a/.starter-kit/docs/v3.0.0/adr-006-deploy-time-image-build.md
+++ b/.starter-kit/docs/v3.0.0/adr-006-deploy-time-image-build.md
@@ -1,0 +1,99 @@
+# ADR-006: Deploy-Time Image Builds with `ContainerImageBuild`
+
+## Status
+
+Accepted (v3.0.0)
+
+## Context
+
+The kit builds three Docker images (`webapp`, `async-job`, and `dsql-migrator`) for Lambda.
+The standard option is CDK's built-in `DockerImageCode.fromImageAsset` — it builds the image with the local Docker CLI at synth time and pushes it to ECR — but this introduces the following issues:
+
+1. **Local Docker becomes mandatory**: Developer machines and CI runners require Docker Desktop / a Docker daemon.
+   Docker Desktop setup on Windows is complex (WSL2 configuration and license review), and CI requires a Docker-in-Docker configuration.
+   This conflicts with the design policy that the kit's Prerequisites should consist only of Node.js + pnpm + AWS CLI (README, "Getting started").
+2. **Architecture mismatch**: Even when developer machines are x86_64 (Intel Macs or Windows), the Lambda execution platform is
+   ARM64. `fromImageAsset` is tied to the local Docker architecture, requiring a `--platform`
+   setting and emulation (QEMU), which harms build time and reliability.
+
+Meanwhile, `webapp` must inject `NEXT_PUBLIC_*` build-time env values from CDK context as
+`buildArgs` (the Amplify SDK requires static values at build time rather than runtime — see the
+[design doc](design.md#lambda-environment) for details). This one location requires a mechanism
+that passes values determined at synth time as build arguments. Although the standard `fromImageAsset` accepts
+`buildArgs`, it also has the issues in 1 and 2 above.
+
+## Decision
+
+Build all three images with the **`ContainerImageBuild` construct from the `@cdklabs/deploy-time-build` package**.
+Do not use `DockerImageCode.fromImageAsset`.
+
+- Implementation: In `apps/cdk/lib/constructs/{webapp,async-job,dsql-migrator/index}.ts`, create
+  `new ContainerImageBuild(this, 'Build', { directory: <repo-root>, platform: Platform.LINUX_ARM64,
+file: 'apps/*/Dockerfile', ignoreMode: IgnoreMode.DOCKER })`, then pass
+  `image.toLambdaDockerImageCode()` to `DockerImageFunction`.
+- Mechanism: When `cdk deploy` runs, a CloudFormation Custom Resource starts a CodeBuild project
+  (ARM64, `general1.small`) on AWS. It builds the image and pushes it to ECR.
+  Multiple `ContainerImageBuild` instances with the same stack and architecture share one CodeBuild project
+  through the construct's internal `SingletonProject`.
+- `webapp` `buildArgs` (`ALLOWED_ORIGIN_HOST`, `NEXT_PUBLIC_EVENT_HTTP_ENDPOINT`,
+  `NEXT_PUBLIC_AWS_REGION`, and others) continue to be embedded at synth time and are passed to
+  the CodeBuild-side build.
+- Also migrate from the predecessor `deploy-time-build` package to its official successor,
+  `@cdklabs/deploy-time-build` (under the cdklabs scope).
+
+### Rejected alternatives
+
+- **`DockerImageCode.fromImageAsset` (retain)**: The Context issues above (Docker requirement and
+  cross-architecture emulation) remain. In particular, it hinders the first-deployment experience
+  on Windows.
+- **Pre-build in CI (such as GitHub Actions), push to ECR, and have CDK reference an existing image**:
+  This harms the kit's reproducibility goal (Reproducibility in DESIGN_PRINCIPLES) that deployment
+  completes with the single command `pnpm exec cdk deploy --all`. The deployment procedure becomes a
+  two-step process, "push → deploy", and pre-build becomes a manual operational burden for downstream apps
+  without CI in place.
+- **Define a CodeBuild project in handwritten CDK code**: This would reimplement the project sharing
+  provided by `SingletonProject` in `deploy-time-build`, the wiring to a CloudFormation Custom Resource,
+  and ECR repository management, which exceeds the kit's scope.
+
+## Consequences
+
+- **Docker is removed from Prerequisites**: README Prerequisites are now only Node.js, pnpm, and AWS CLI.
+  Windows developers can deploy without setting up WSL2 + Docker Desktop.
+- **Docker layer caching is unavailable (trade-off)**: `ContainerImageBuild` updates the Custom Resource when
+  the input Asset (the build context after `.dockerignore` is applied), `buildArgs`, or other inputs change,
+  and CodeBuild performs a **full build from a clean environment**.
+  Compared with local Docker builds, it loses incremental build acceleration from reusing layers for
+  `node_modules` installation and `next build` (the model is that all layers rebuild every time, even when
+  only one line of code changes). One full build takes several minutes to around 10 minutes per image.
+  This is noticeable during iterative development.
+- **Deployments without input changes do not rebuild**: `ContainerImageBuild` embeds the input Asset
+  content hash in the Custom Resource properties, so a `cdk deploy` in which none of the source, Dockerfile,
+  or `buildArgs` have changed makes the Custom Resource a No-Op and does not start CodeBuild. There is no
+  situation where CodeBuild for an untouched stack runs every time and increases costs.
+- **CodeBuild concurrent execution quota**: The concurrent execution quota for ARM/Small defaults to 1
+  (for the entire AWS account). The three images in the same stack share one project through `SingletonProject`,
+  so they run sequentially. If another stack or project uses ARM/Small CodeBuild concurrently, it is queued.
+  If this becomes a frequent issue, the quota can be increased through Service Quotas (via AWS Support).
+- **Required IAM permissions**: `ContainerImageBuild` configures multiple permission principals together:
+  (a) the CDK/CloudFormation execution role (equivalent to `cdk-*-cfn-exec-role-*`) must be able to **create**
+  the CodeBuild project, ECR repository, Custom Resource Lambda, and its execution role;
+  (b) the Custom Resource Handler Lambda automatically generated by the construct must receive the
+  `codebuild:StartBuild` permission (configured by `ContainerImageBuild`);
+  (c) the service role of the CodeBuild project automatically generated by the construct must receive ECR
+  pull/push permissions (configured by the construct through `repository.grantPullPush(project)`).
+  The role created by standard `cdk bootstrap` has the permissions in (a). However, downstream apps that use
+  a custom bootstrap with restricted permissions must explicitly add permissions to create these resources.
+  Because (b) and (c) are auto-wired by the construct, kit users need to consider only (a).
+- **CodeBuild execution cost**: Usage charges for `general1.small` are added (a small per-build charge; see
+  [AWS CodeBuild pricing](https://aws.amazon.com/codebuild/pricing/) for current rates). This can become
+  non-negligible during iterative deployment in development, but as described above, CodeBuild does not start
+  for deployments without input changes, so the impact in normal operation is small.
+- **The `dsql-migrator` requires an explicit content hash for change detection**: Because the image content hash of
+  `ContainerImageBuild` is not determined at CDK synth time, standard CDK/CloudFormation change detection
+  cannot detect changes to `migrations/`. The migrator Construct calculates a content hash of the entire
+  `migrations/` directory and fills this gap by:
+  (1) invalidating the Lambda published version with `Function.invalidateVersionBasedOn(hash)`, and
+  (2) injecting it as `MigrationHash` into the CDK Trigger's `Custom::Trigger` property
+  (implementation: `apps/cdk/lib/constructs/dsql-migrator/index.ts`).
+  For details of this handling and the design decision (why it selects a whole-directory hash rather than
+  sharing an extension list), see [ADR-001](adr-001-dsql-drizzle-migrator.md).

--- a/.starter-kit/docs/v3.0.0/adr-007-cloudfront-flat-rate.md
+++ b/.starter-kit/docs/v3.0.0/adr-007-cloudfront-flat-rate.md
@@ -1,0 +1,134 @@
+# ADR-007: Compatibility with CloudFront flat-rate pricing plans
+
+## Status
+
+Accepted (v3.0.0)
+
+## Context
+
+Amazon CloudFront introduced **flat-rate pricing plans** (Free / Pro / Business / Premium) in 2025. They bundle CloudFront CDN, AWS WAF, DDoS protection, CloudWatch Logs ingestion, Route 53 DNS,
+S3 storage credits, and serverless edge compute at a fixed monthly price, with no overage charges
+(Source: [CloudFront flat-rate pricing plans](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/flat-rate-pricing-plan.html)). The **Free plan** costs $0 per month and
+includes 1M requests + 100 GB of data transfer — comfortably within the kit's expected usage scale
+(README.md Cost section: 100 users/month × 1000 requests/user).
+
+To enroll in this plan, the CloudFront distribution configuration must meet the following two
+constraints:
+
+1. **Custom cache policies are prohibited**: Only AWS managed cache policies are available. Custom
+   cache policies are permitted only on Business / Premium plans (Source: the "Custom caching rules"
+   row in [Pricing plan features](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/flat-rate-pricing-plan.html)
+   — the Free and Pro columns are blank; only Business and Premium are marked Yes).
+2. **A WAF Web ACL association is required**: The distribution must have an associated AWS WAF Web ACL
+   (scope=CLOUDFRONT). This association cannot be removed unless returning to pay-as-you-go (Source:
+   the passage beginning "A valid AWS WAF protection pack (web ACL) must remain associated..." in
+   [Using AWS WAF with CloudFront Flat-Rate Pricing Plans](https://docs.aws.amazon.com/waf/latest/developerguide/cloudfront-features.html)).
+
+The initial v3 kit configuration used a **custom `CachePolicy`** (the shared `SharedCachePolicy`) for
+the default behavior, violating constraint 1 and preventing plan enrollment. As a side effect of that
+policy's `allowList`, Next.js App Router RSC payloads (Content-Type `text/x-component`) could also
+poison the normal HTML cache (Issue #176). A point fix that adds RSC-related headers to the `allowList`
+(PR #183) was attempted, but although it resolves RSC cache poisoning, constraint 1 remains and it
+does not enable plan enrollment.
+
+Given the kit's purpose (a prototype / learning environment for a serverless stack) and cost target
+(starting under $10/month — DESIGN_PRINCIPLES), it is highly valuable to provide enrollment in the
+Free plan as the kit's default configuration.
+
+## Decision
+
+Wire the CloudFront distribution by default to a configuration eligible for the flat-rate plans
+(Free / Pro). Because CDK does not support the enrollment operation itself, document the console
+steps in the README while **removing configuration elements that prevent enrollment**.
+
+### Use only AWS managed cache policies (`apps/cdk/lib/constructs/cf-lambda-furl-service/service.ts`)
+
+- **default behavior → `CachePolicy.CACHING_DISABLED`** (min/max/default TTL = 0).
+  CloudFront does not cache dynamic responses at all. Consequently:
+  - Poisoning of the normal HTML cache by RSC payloads (Issue #176) cannot occur in principle
+    — there is no cacheable response. This replaces the point fix in PR #183 that adjusts the
+    `allowList` with a structural resolution.
+  - Cookie / Authorization do not need to be included in the cache key (there is no cache key).
+  - As before, `OriginRequestPolicy.ALL_VIEWER_EXCEPT_HOST_HEADER` forwards all headers, cookies,
+    queries, and the body to the origin. Application behavior at the origin remains unchanged.
+- **`/_next/static/*` → `CachePolicy.CACHING_OPTIMIZED`**. Cache the immutable, content-hashed build
+  assets emitted by Next.js at the edge instead of reaching the Lambda origin every time. Because the
+  assets are public, depend only on the path, and are immutable, the managed cache policy's cache key
+  (without cookies or queries) is safe. The Free plan uses 2 of its 5 cache behavior limit.
+
+### Include a WAF Web ACL by default (`apps/cdk/lib/us-east-1-stack.ts`)
+
+Create a minimal `CfnWebACL` in `us-east-1` (scope `CLOUDFRONT`, default action `allow`) and associate
+it with the distribution. The only rule is **`AWSManagedRulesKnownBadInputsRuleSet`**. Deliberately do
+not include other managed rule groups / rate-based rules (described below). Export its ARN cross-region
+to the main stack, then associate it through the `webAclId?` property of
+`CloudFrontLambdaFunctionUrlService`.
+
+### Opt-out path (copy-and-edit)
+
+Do not provide a runtime flag for downstream apps that do not need WAF. Instead, following the kit's
+copy-and-grow principle, provide opt-out through a **deletion-based pattern**: remove Web ACL creation
+from `us-east-1-stack.ts` and do not pass `webAclId` from `bin/cdk.ts` (`webAclId?` is optional in
+`service.ts`, so removal alone works). Document this procedure in the README.
+
+### Rationale for limiting WAF rules to `KnownBadInputs`
+
+Keep the managed rule set minimal to avoid a starter kit experience where users receive an
+"unexplained 403":
+
+- **Exclude `AWSManagedRulesCommonRuleSet`**: `NoUserAgent_HEADER` creates false positives for health
+  checks / server-side fetches, and `SizeRestrictions_Cookie` creates false positives for the large
+  authentication cookies from Amplify / Cognito (known patterns based on actual measurements).
+- **Exclude `AWSManagedRulesAmazonIpReputationList`**: Because it blocks based on the source IP
+  reputation regardless of request content, it appears to end users as an unexplained 403.
+  There is no debugging path.
+- **Exclude rate-based rules**: They trigger on legitimate traffic such as shared NATs / corporate
+  proxies, load tests, and Next.js prefetch bursts, causing blocks whose cause is not visible.
+- **Keep `KnownBadInputs`**: It matches signatures of real attacks such as Log4Shell, so there is
+  little room for false positives on legitimate traffic.
+
+After understanding the nature of their traffic, users can decide whether to add rules within the
+Free plan limit (5 rules) for their downstream apps.
+
+### Rejected alternatives
+
+- **Keep the custom `CachePolicy` and add RSC headers to the `allowList`** (the direction in PR #183):
+  This resolves RSC cache poisoning, but constraint 1 (the custom cache policy prohibition) remains,
+  so Free/Pro plan enrollment is impossible. Resolving RSC cache poisoning also carries the
+  operational burden of maintaining the `allowList`.
+- **Managed `USE_ORIGIN_CACHE_CONTROL_HEADERS` instead of `CACHING_DISABLED`**: This meets the
+  managed cache policy constraint, but responses can be cached depending on the origin's
+  `Cache-Control` headers. Because Next.js App Router returns RSC/HTML/API from a single Lambda,
+  incorrect header control can cache different Content-Types at the same path. The structural
+  guarantee is lost.
+- **Include `CommonRuleSet` + `AmazonIpReputationList` + rate-based rules by default**: This appears
+  to be a general "WAF best practice," but turns the starter kit learning experience into
+  "debugging unexplained 403s." The false-positive patterns above are based on actual measurements.
+  It is better for users to add them incrementally.
+- **Automate plan enrollment with CDK**: CloudFront plan enrollment cannot currently be operated
+  through CDK / CloudFormation. Manual operation in the console is the only path, so the README
+  guides users through it.
+
+## Consequences
+
+- **A path to Free plan enrollment is prepared**: The single command `pnpm exec cdk deploy --all`
+  provisions the distribution + Web ACL, and enrollment only requires selecting
+  **Manage subscription → Free plan** in the console (see README "Enroll in the CloudFront Free plan").
+- **WAF billing until enrollment**: Before enrollment, the Web ACL is billed at [standard AWS WAF pricing](https://aws.amazon.com/waf/pricing/)
+  ($5/month + $1 × number of rules). Unexpected charges occur if the enrollment procedure is not
+  performed immediately after deployment, so the README explicitly includes a warning and points to
+  `README.md#4-enroll-in-the-cloudfront-free-plan`.
+- **All dynamic requests reach the Lambda origin**: Because the default behavior is `CACHING_DISABLED`,
+  authenticated requests, HTML, RSC, and APIs all reach Lambda. Lambda / Lambda@Edge costs (see the
+  Cost section) are usage-based and outside the flat-rate plan. Downstream apps for which SSR/Lambda
+  cost becomes a concern should consider revisiting their caching strategy (introduce custom cache
+  policies on Business/Premium or switch to pay-as-you-go).
+- **Static asset offloading**: `/_next/static/*` does not reach Lambda because of the edge cache.
+  The Free plan's 100 GB data transfer contributes significantly here.
+- **`webAclId?` and `geoRestriction?` are optional props of the `CloudFrontLambdaFunctionUrlService`
+  construct**: A downstream app that wants to remove the Web ACL can return to a pay-as-you-go
+  configuration simply by not passing `webAclId` from `bin/cdk.ts` (and removing the Web ACL resource
+  itself). Opt-out compatibility is ensured at the construct level.
+- **AWS WAF Web ACLs can only be created in `us-east-1`** (a scope=CLOUDFRONT requirement). Placing it
+  in the separate `us-east-1-stack.ts` and passing its ARN to the main stack uses the same
+  cross-region-reference pattern already used for Lambda@Edge and the ACM certificate.

--- a/.starter-kit/docs/v3.0.0/design.md
+++ b/.starter-kit/docs/v3.0.0/design.md
@@ -1,0 +1,277 @@
+# v3.0.0 Design document
+
+## Overview
+
+v3 simultaneously changes the DB engine (Aurora Serverless v2 → Aurora DSQL), ORM (Prisma → Drizzle), package manager (npm → pnpm workspaces), and linter (ESLint + Prettier → oxlint + oxfmt). The four changes are interdependent, and resolving them together avoids wasting effort on intermediate states.
+
+For the motivations for these changes, the rationale for the technology choices, and rejected alternatives, see the ADRs. This document describes the implementation details of the decisions made in the ADRs.
+
+- [ADR-001: Aurora DSQL + Drizzle ORM + custom migration runner](adr-001-dsql-drizzle-migrator.md)
+- [ADR-002: pnpm workspaces monorepo](adr-002-pnpm-workspaces.md)
+- [ADR-003: oxlint + oxfmt](adr-003-oxlint-oxfmt.md)
+- [ADR-004: Keeping the DSQL admin role](adr-004-dsql-admin-role.md)
+- [ADR-005: Unified migration file formats (drop `.ts`, keep `.sql` + `.mjs`)](adr-005-migration-file-format.md)
+- [ADR-006: Deploy-time image build via `ContainerImageBuild`](adr-006-deploy-time-image-build.md)
+- [ADR-007: CloudFront flat-rate pricing plan compatibility](adr-007-cloudfront-flat-rate.md)
+
+## Target architecture
+
+```
+pnpm-workspace.yaml
+package.json                      # root (scripts and devDependencies only)
+apps/
+  cdk/                            # CDK infrastructure
+  webapp/                         # Next.js app (no jobs or migration runner)
+  async-job/                      # extracted from webapp/src/jobs/
+packages/
+  db/                             # Drizzle schema, client, migration SQL, runner
+  shared-types/                   # job payload types (Zod schemas)
+  event-utils/                    # SigV4-signed utility for sending to AppSync Events
+```
+
+Dependency direction:
+
+```
+apps/webapp       → @repo/db, @repo/shared-types, @repo/event-utils
+apps/async-job    → @repo/db, @repo/shared-types, @repo/event-utils
+apps/cdk          (no direct dependencies — references Docker build paths only)
+```
+
+Apps do not depend on one another. Internal packages also do not depend on one another. The scope for internal packages is `@repo/`.
+
+## Aurora DSQL
+
+### Connection pattern
+
+DSQL accepts connections only through IAM authentication. `@aws/aurora-dsql-node-postgres-connector` automates IAM authentication token generation and passes the token to node-postgres. Reasons for choosing this connector:
+
+- It is the official AWS Node.js connector and internally manages the 15-minute IAM token lifetime and refreshes.
+- It provides `AuroraDSQLPool`, which extends the node-postgres (`pg`) `Pool` interface and can be passed directly to Drizzle ORM through `drizzle({ client: pool })`.
+- It automatically uses IAM authentication from the execution role in a Lambda environment and AWS profile credentials in the local CLI.
+
+`@aws/aurora-dsql-postgres-js-connector` (for Postgres.js) also exists, but using `AuroraDSQLPool` with Drizzle's node-postgres driver is simpler.
+
+### DB roles and permission model
+
+DSQL has a two-layer permission model that integrates PostgreSQL's role system with IAM:
+
+- **admin role** (`dsql:DbConnectAdmin`): DDL + DML + role management. The only built-in role, automatically created when the cluster is created.
+- **custom roles** (`dsql:DbConnect`): DML only. Create them by connecting as `admin` and running `CREATE ROLE ... WITH LOGIN` + `AWS IAM GRANT` + `GRANT ... ON ALL TABLES IN SCHEMA`.
+
+In this kit, all Lambda functions (webapp, async-job, migrator) connect with the `admin` role. From a least-privilege perspective, webapp and async-job only need DML, but the ordering dependency between CDK and migrations (passing the Lambda execution role ARN) does not justify the added complexity for a starter kit, so the kit keeps `admin`. v2 also connected everything with the master user, and v3 has already improved the authentication layer by moving to IAM temporary tokens. For details, see [ADR-004](adr-004-dsql-admin-role.md).
+
+### DDL constraints
+
+Source: https://docs.aws.amazon.com/aurora-dsql/latest/userguide/ (verified 2026-03-21)
+
+This section records the constraints that support design decisions. As numerical quotas (connection count, table count, and so on) may change, see the [official documentation](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/CHAP_quotas.html).
+
+#### Transaction constraints
+
+- DDL and DML require separate transactions.
+- A transaction can contain only one DDL statement.
+- A write transaction has a 3,000-row limit (applies to INSERT, UPDATE, and DELETE).
+- A write transaction has a 10 MiB limit.
+- The maximum transaction execution time is 5 minutes.
+- The isolation level is fixed at Repeatable Read.
+- OCC (optimistic concurrency control): returns a serialization error on a write conflict. The application layer must retry.
+
+#### ALTER TABLE supported actions
+
+Actions supported by ALTER TABLE are extremely limited. The following are all officially supported actions:
+
+```sql
+ADD [ COLUMN ] [ IF NOT EXISTS ] column_name data_type
+ALTER [ COLUMN ] column_name { SET GENERATED { ALWAYS | BY DEFAULT } | SET sequence_option | RESTART [...] }
+ALTER [ COLUMN ] column_name DROP IDENTITY [ IF EXISTS ]
+OWNER TO { new_owner | CURRENT_ROLE | CURRENT_USER | SESSION_USER }
+RENAME [ COLUMN ] column_name TO new_column_name
+RENAME CONSTRAINT constraint_name TO new_constraint_name
+RENAME TO new_name
+SET SCHEMA new_schema
+```
+
+Source: https://docs.aws.amazon.com/aurora-dsql/latest/userguide/alter-table-syntax-support.html
+
+All operations not included above (`DROP COLUMN`, `ALTER COLUMN TYPE`, `SET/DROP NOT NULL`, `SET/DROP DEFAULT`, and `DROP CONSTRAINT`) require table recreation. This constraint is the basis for the validation patterns in the migration runner and the unfixable workflow.
+
+#### Unsupported data types
+
+- `SERIAL` / `BIGSERIAL` / `SMALLSERIAL` — use an IDENTITY column or UUID.
+- Array types (such as `TEXT[]`) — store in TEXT (array types are supported at query runtime).
+- Custom types / ENUM types.
+- Extension types such as PostGIS.
+
+> `json` / `jsonb` are **available** because DSQL added support in 2026 (automatic compression, a 1 MiB post-compression limit, and **not indexable**). Extract values used as search or sort keys into independent columns. `jsonb` is recommended for semi-structured data.
+
+#### SEQUENCE / IDENTITY column constraints
+
+- Explicitly specifying `CACHE` is required (it is optional in PostgreSQL).
+- Supported CACHE values: only `1` or `>= 65536` (intermediate values are not allowed).
+- Only the `BIGINT` data type is supported.
+- SERIAL types are unsupported → use `GENERATED { ALWAYS | BY DEFAULT } AS IDENTITY (CACHE ...)`.
+
+#### Index constraints
+
+- `CREATE INDEX ASYNC` is required (synchronous INDEX is not allowed).
+- A maximum of 24 indexes per table.
+- A maximum of 8 columns per index.
+
+#### Other DDL constraints
+
+- FOREIGN KEY is unsupported — enforce referential integrity at the application layer.
+- TRUNCATE is unsupported — use `DELETE FROM` instead.
+- Temporary tables are unsupported.
+- Triggers are unsupported.
+- PL/pgSQL is unsupported — SQL functions only.
+- Extensions are unsupported (PostGIS, pgvector, and so on).
+
+## Custom migration runner
+
+For the rationale, see [ADR-001](adr-001-dsql-drizzle-migrator.md). The following is the implementation specification.
+
+### Three-layer design
+
+Each layer depends only on adjacent layers, with no dependencies that skip a layer:
+
+- **Core logic** (`packages/db/src/migrate.ts`): Receives `pg.Pool` and applies files with supported extensions (`.sql` / `.mjs`) in name order. For `.sql`, transforms it to DSQL compatibility with `transformSql`, then splits it at blank lines (`\n\n`) and executes one statement at a time with `BEGIN`/`COMMIT` (runtime transformation provides defense in depth for handwritten SQL that bypasses generation-time transformation). For `.mjs`, calls the `default` export function (`async function(client)`). It has no dependency on CDK, Lambda, or Drizzle. It can be reused with any ORM or deployment tool.
+- **Lambda handler** (`apps/cdk/lib/constructs/dsql-migrator/handler.ts`): A thin wrapper that creates a Pool from Lambda environment variables and calls `migrate()`.
+- **CDK Construct** (`apps/cdk/lib/constructs/dsql-migrator/index.ts`): Automatically runs during `cdk deploy` using `DockerImageFunction` (`ContainerImageBuild`) + a CDK Trigger. It injects a content hash for the entire `migrations/` directory into `invalidateVersionBasedOn` (Lambda published-version invalidation) and the `Custom::Trigger` properties, ensuring reruns when migrations change (because deploy-time builds make the image hash indeterminate during synth, preventing CDK change detection. See C1 in [ADR-001](adr-001-dsql-drizzle-migrator.md) for details).
+
+This separation lets the core logic work with ORMs other than Drizzle, the Lambda handler work with deployment tools other than CDK, and the CDK Construct remain independent of how migration SQL is generated.
+
+### Migration state management
+
+The `_migrations` table (name = full file name, executed_at) tracks application state. Skip `already exists` errors for idempotency. Because one migration is one file with one extension, there is no ambiguity in name.
+
+For why content-hash-based tampering detection was rejected (and how it differs from the `migrations/` directory hash used to rerun at deployment), see [Consequences in ADR-001](adr-001-dsql-drizzle-migrator.md).
+
+### Automatic SQL transformation
+
+`check-dsql-compat.ts` automatically transforms the output of drizzle-kit generate to DSQL compatibility. Transformation rules:
+
+| Transformation            | Input pattern                                                     | Output                                                                                          |
+| ------------------------- | ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| Statement delimiter       | `--> statement-breakpoint\n`                                      | `\n\n` (blank line. The runner splits SQL at this blank line)                                   |
+| INDEX → ASYNC             | `CREATE INDEX` / `CREATE UNIQUE INDEX`                            | `CREATE INDEX ASYNC` / `CREATE UNIQUE INDEX ASYNC` (does not transform if ASYNC already exists) |
+| Remove CONSTRAINT FK line | `,\n  CONSTRAINT "..." FOREIGN KEY (...) REFERENCES "..."("...")` | Remove the entire line (including the comma)                                                    |
+| Remove unnamed FK line    | `,\n  FOREIGN KEY (...) REFERENCES "..."("...")`                  | Remove the entire line                                                                          |
+| Remove inline REFERENCES  | `"col" text NOT NULL REFERENCES "Table"("id")`                    | `"col" text NOT NULL` (remove only the REFERENCES part and retain the column definition)        |
+
+FK removal has two patterns because drizzle-kit emits FKs in two forms: a CONSTRAINT line (an independent constraint definition at the end of `CREATE TABLE`) and inline REFERENCES (appended to the end of a column definition). Remove a CONSTRAINT line as a whole line, but remove only the REFERENCES part for inline REFERENCES to avoid breaking the column definition. Removal order is also important: unless CONSTRAINT lines are removed first, the inline REFERENCES regular expression also matches REFERENCES within CONSTRAINT lines, leaving incomplete lines behind.
+
+### SQL validation
+
+Before executing each SQL statement, the runner validates DSQL-incompatible patterns. It detects:
+
+| Pattern                                                            | Reason                                                                            |
+| ------------------------------------------------------------------ | --------------------------------------------------------------------------------- |
+| `CREATE INDEX` without `ASYNC`                                     | DSQL does not permit synchronous INDEX                                            |
+| `REFERENCES` / `FOREIGN KEY`                                       | DSQL does not support FK                                                          |
+| `ALTER COLUMN ... TYPE` / `SET DATA TYPE`                          | Not included in the official ALTER TABLE syntax                                   |
+| `DROP COLUMN`                                                      | Not included in the official ALTER TABLE syntax                                   |
+| `SET NOT NULL` / `DROP NOT NULL`                                   | Not included in the official ALTER TABLE syntax                                   |
+| `SET DEFAULT` / `DROP DEFAULT`                                     | Not included in the official ALTER TABLE syntax                                   |
+| `DROP CONSTRAINT`                                                  | Not included in the official ALTER TABLE syntax                                   |
+| `ADD COLUMN ... DEFAULT`/`NOT NULL`/`CHECK`/`UNIQUE`/`PRIMARY KEY` | DSQL ADD COLUMN cannot add constraints (add as nullable and backfill with UPDATE) |
+| `SERIAL`                                                           | DSQL-unsupported type                                                             |
+| `TRUNCATE`                                                         | DSQL unsupported. Use `DELETE FROM` instead                                       |
+
+### .mjs migrations
+
+Use these when table recreation (DROP COLUMN, ALTER COLUMN TYPE, and so on) or batched data migration exceeding 3,000 rows is required. Export `export default async function(client)` and supplement types with JSDoc (`@param {import('pg').PoolClient} client`).
+
+The only canonical formats in `migrations/` are `.sql` and `.mjs`; `.ts` is unsupported. The reason is that local (tsx/node) and Lambda (node) **execute the same files without transformation** — inserting a transpilation step causes files to diverge between local and deployed environments, creating the conditions for double execution (for details, see [ADR-005](adr-005-migration-file-format.md)).
+
+Constraints:
+
+- Lambda's maximum execution time is 15 minutes. Migrations exceeding it require a separate mechanism such as Step Functions (outside the runner's scope).
+- The migrator Dockerfile copies `migrations/` as-is (no transpilation step).
+
+### Workflow for unfixable patterns
+
+When `drizzle-kit generate` produces DSQL-incompatible SQL, `check-dsql-compat.ts` detects the error and guides the following procedure:
+
+1. Restore generated output with `git checkout -- migrations/`.
+2. Generate an empty migration file and an updated snapshot with `drizzle-kit generate --custom --name=<name>`.
+3. Write table recreation in `.sql` (3,000 rows or fewer) or `.mjs` (batched migration).
+4. Apply it with `pnpm --filter @repo/db run migrate`.
+
+For why the runner does not automatically roll back on errors, see [Consequences in ADR-001](adr-001-dsql-drizzle-migrator.md).
+
+### CI validation of migration consistency
+
+CI validates two types of consistency:
+
+- **Chain consistency** (`check:migrations` in `packages/db`'s `check:ci` = `drizzle-kit check`): Detects snapshot-chain forks (duplicate `prevId`) and divergence from `schema.ts`.
+- **Generate drift** (an independent step in `.github/workflows/build.yml`): Runs `generate` and fails if it produces differences in `migrations/` (detects cases where `schema.ts` changes without generate). `generate` runs without a DB connection and non-interactively (closes stdin to prevent CI from hanging at a rename prompt).
+
+## DSQL compatibility strategy
+
+Detect DSQL-incompatible patterns at two stages: coding time and migration time.
+
+**Layer 1 — oxlint (schema-definition level)**: `no-restricted-imports` blocks imports of `serial`, `smallserial`, and `bigserial` from `drizzle-orm/pg-core` (`json`/`jsonb` are allowed because DSQL supports them). This provides immediate feedback in the editor and CI. (`no-restricted-syntax` for `.references()` is configured but does not work as of oxlint v1.56.0. See [ADR-003](adr-003-oxlint-oxfmt.md) for details.)
+
+**Layer 2 — SQL validation (generated-SQL level)**: `check-dsql-compat.ts` automatically transforms drizzle-kit output and validates patterns that cannot be automatically fixed.
+
+Why two layers: let oxlint handle what it can detect, and limit SQL regular expressions to “problems at the generated-SQL level that cannot be detected in the TypeScript world.” Do not prohibit adding or removing `notNull()` or `default()` in lint: it cannot distinguish legitimate use on a new column from an incompatible change to an existing column. Detect these at the generated-SQL level (`SET NOT NULL`, `DROP DEFAULT`, and so on).
+
+## pnpm workspaces + Docker build
+
+For the rationale, see [ADR-002](adr-002-pnpm-workspaces.md). The following describes implementation constraints and mitigations.
+
+### Remote builds with ContainerImageBuild
+
+Build all container images (webapp, async-job, dsql-migrator) with `ContainerImageBuild` from `@cdklabs/deploy-time-build`. Do not use `DockerImageCode.fromImageAsset` (local Docker builds).
+
+Motivation: eliminate local Docker as a deployment-time dependency. This removes the need to set up Docker Desktop on Windows or Docker-in-Docker in CI environments, so Docker can be removed from Prerequisites.
+
+Mechanism: during `cdk deploy`, a CloudFormation custom resource builds images with CodeBuild (ARM/Small) and pushes them to ECR. `ContainerImageBuild` instances in the same stack and architecture share one CodeBuild project through `SingletonProject`.
+
+Trade-offs:
+
+- Docker layer caching does not work (a full build occurs every time).
+- The default concurrent-build quota for CodeBuild ARM/Small is one, so multiple builds queue and run serially. You can increase it in Service Quotas.
+
+### Script conventions
+
+Each subpackage defines standard task names (`dev`, `build`, `test:unit`, `lint`, `check:ci`, and so on) in its own `package.json`; run them together from the root with `pnpm -r run <task>`. Do not add alias scripts for these tasks to the root `package.json`: it is redundant because each package owns its own scripts, and indirect calls with `--if-present` make debugging difficult.
+
+The pre-commit hook uses `simple-git-hooks` + `lint-staged`: it runs oxlint/oxfmt on staged files, then runs `test:unit` for all packages. The `prepare` script automatically installs the hook during `pnpm install`. The oxlint invocation in lint-staged cannot type check through `typeCheck`: lint-staged passes only staged files as arguments, which is incompatible with type checking that requires resolving tsconfig for the entire project. CI's `check:ci` (`typeCheck: true` in `oxlintrc.json`) ensures type checking.
+
+### Docker build constraints
+
+Docker builds in strict mode have four pitfalls (see [Consequences in ADR-002](adr-002-pnpm-workspaces.md) for details):
+
+1. `pnpm install --filter` does not hoist transitive dependencies → install all dependencies without `--filter`.
+2. CDK `DockerImageCode.fromImageAsset` does not read `.dockerignore` → `ignoreMode: IgnoreMode.DOCKER` is required.
+3. esbuild output using `--format=esm` requires a `.mjs` extension in Lambda.
+4. `--external:@aws-sdk/*` does not exclude `@aws/*` packages.
+
+## ESM eager evaluation and Proxy lazy initialization
+
+`client.ts` combines Proxy-based lazy initialization and a `globalThis` singleton to solve two problems.
+
+1. **Avoid ESM eager evaluation (Proxy)**: In ESM, top-level `export const db = drizzle(...)` is evaluated immediately when the module is imported. Merely having `cli.ts` run `import { getPool } from './client'` also initializes `db`, causing a crash when `DSQL_ENDPOINT` is unset. Using a Proxy defers initialization until actual property access without changing existing code that imports `db`. A function-wrapping approach (`getDb()`) was also considered but rejected because it would require changing every call site.
+2. **Prevent connection leaks during Next.js hot reload (`globalThis`)**: The Next.js dev server reevaluates modules, so without retaining the instance on `globalThis`, a new connection pool is created and leaked on every reload. Using a `globalThis` singleton as the target of Proxy lazy initialization solves both problems at once.
+
+## Test design
+
+Tests for the migration runner and the DSQL compatibility check use a two-layer, fixture-based design.
+
+### Fixture-based tests
+
+Regular-expression operations on SQL strings risk false positives (raising errors for valid SQL) and false negatives (missing incompatible SQL). Because inputs are limited to “output from drizzle-kit generate,” use actual output as fixtures. Each fixture is an `input.sql` / `expected.sql` pair that explicitly verifies transformation input and output.
+
+### Separation of unit and integration tests
+
+- **unit tests**: Mock `pg.Pool` and the file system. They run immediately without a DB. They ensure comprehensive pattern coverage for transformation logic and validation.
+- **integration tests**: Run against a real DSQL cluster. They prove that transformed SQL works on DSQL, verify idempotency, and confirm the actual behavior of skipping `already exists`. They run only when the `DSQL_ENDPOINT` environment variable is set.
+
+This separation provides fast feedback in CI using only unit tests, while developers run integration tests that require a DSQL cluster in their local environment.
+
+### Integration test isolation strategy
+
+To avoid polluting the production `migrations/` directory, integration tests create a temporary migrations directory under `os.tmpdir()` and place test SQL there. Before each test, clean up the target tables and the `_migrations` table with `DROP TABLE IF EXISTS` to remove state dependencies between tests.
+
+Reason for this approach: an approach using a test DB schema (`SET search_path`) risks reaching DSQL's schema-count limit (10). A transaction rollback approach cannot be used because DDL does not work inside transactions in DSQL. Dropping tables plus a temporary directory is the simplest approach that does not conflict with DSQL constraints.

--- a/.starter-kit/docs/v3.0.0/migration-prompt.md
+++ b/.starter-kit/docs/v3.0.0/migration-prompt.md
@@ -1,0 +1,626 @@
+# v3 Migration Prompt
+
+## Purpose
+
+This document is a starting-point template for planning a migration from v2 to v3. Because each downstream project has user-specific schemas, custom extensions, and data volumes, do not execute this document as-is. Instead, create a project-specific migration plan based on the results of the Phase 1 pre-assessment.
+
+Planning flow:
+
+1. Read this entire document to understand the phase structure and rules of conduct
+2. Execute Phase 1 (backup and pre-assessment) to analyze the user's schema, data, and custom extensions
+3. Based on the analysis results, document the concrete tasks and checkpoints for each phase as a project-specific plan
+4. Execute each phase in order according to the plan
+
+## Prerequisites
+
+- Node.js >= v22 (v3 Lambda runtime / Docker builds use Node 24; Node 24 is also recommended locally), pnpm >= v10.26 (v3 root `package.json` is pinned to `packageManager: pnpm@10.34.4`), and AWS CLI with an IAM profile configured
+- Docker is required only for local verification. Image builds for actual deployments run in AWS **CodeBuild** (through the `ContainerImageBuild` construct in `@cdklabs/deploy-time-build` — see [ADR-006](adr-006-deploy-time-image-build.md) for details). Deployment is possible on Windows or in environments without Docker
+- **The CloudFormation execution role for CDK bootstrap must have permission to create CodeBuild projects, ECR repositories, and Custom Resource Lambdas.** The default bootstrap with `AdministratorAccess` requires no additional configuration. Downstream apps that use a hardened bootstrap must explicitly grant permissions to create these resources
+- The user's v2 application source code
+- Access to the user's AWS account (Aurora Serverless v2 cluster, Cognito, and so on)
+- **A copy of the v3 kit for reference** — Read the v3 kit to understand its directory structure, configuration files, and schema patterns. This document does not describe information that can be read from the v3 kit's code
+
+## Rules of conduct
+
+⚠️ **Most important rule: Do NOT skip phases.** In particular, Phase 5 (database migration) requires a phased CDK deploy. If you remove the Aurora v2 resource definitions without setting RETAIN, CloudFormation deletes the cluster and production data is lost. Always proceed step by step in this order: Phase 5-1 (RETAIN + add DSQL) → 5-2 (data migration) → 5-3 (cutover) → 5-4 (remove old resources).
+
+1. **If the current phase's checkpoint fails, do not proceed to the next phase.** Fix the problem first
+2. **Phase 5-4 requires the user's explicit approval.** Present the list of resources to be deleted and wait for confirmation
+3. **Before Phase 5-2, reconfirm that the Aurora v2 snapshot from Phase 1 exists.** If it does not, create a new snapshot before proceeding
+4. **Rollback safety**: Before Phase 5-4, you can return to Aurora v2 at any time by restoring from the snapshot and redeploying the v2 CDK code. Rollback after Phase 5-4 requires restoration from the snapshot and recreation of VPC resources
+5. **Data risk by phase**: Phases 1–4 change code only (no data risk). Phase 5-1 only adds resources. Phase 5-2 copies data (the source remains unchanged). Phase 5-3 switches traffic, but old resources remain. **Only Phase 5-4 is destructive**
+
+## Files that can be copied directly from the v3 kit
+
+The following files are foundation code that does not contain sample-specific customization in the v3 kit, and are candidates for direct copying from the v3 kit. Copy without transformation or hand-editing only files whose same-named counterpart in the v2 downstream app was confirmed unchanged by the user during the inventory in section 1-4 (see [1-4. Inventory user custom extensions](#1-4-inventory-user-custom-extensions)).
+
+If the downstream app contains modifications, merge only the v3 changes; do not overwrite it by copying the entire file. In particular, the following files are entry points that integrate multiple Constructs, props, and environment variables. **Always use a 3-way merge when copying them**, because they are likely to contain custom Constructs or custom props:
+
+- `apps/cdk/lib/main-stack.ts` — Central location for custom Construct instantiation and dependency injection
+- `apps/cdk/lib/us-east-1-stack.ts` — May contain custom Lambda@Edge functions or ACM certificates
+- `apps/cdk/bin/cdk.ts` — User configuration such as stack names, tags, and domain names
+- `apps/webapp/src/proxy.ts` — Location for authorization logic customization
+- `apps/webapp/next.config.ts` — Merge while preserving the user's existing configuration
+
+| Source (v3 kit)                                   | Notes                                                                                                                                                                                                                                                                                                                                    |
+| ------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pnpm-workspace.yaml`                             | `packages: [apps/*, packages/*]` and `minimumReleaseAge: 4320` (supply-chain protection that excludes npm packages published within the last 72 hours from dependency resolution)                                                                                                                                                        |
+| `package.json` (root)                             | Includes `packageManager: pnpm@10.34.4`, `engines.pnpm: >=10.26`, `prepare: simple-git-hooks`, and configuration for `simple-git-hooks` / `lint-staged`. Do not retain the user's root scripts (each workspace owns its own scripts)                                                                                                     |
+| `oxlintrc.json`                                   | Blocks DSQL-incompatible imports (`serial`/`smallserial`/`bigserial`) through linting. Enables plugins including `typescript`, `unicorn`, `react`, and `import/no-cycle`                                                                                                                                                                 |
+| `.oxfmtrc.json`                                   | —                                                                                                                                                                                                                                                                                                                                        |
+| `.dockerignore`                                   | For the monorepo root. Excludes `**/node_modules`, `**/.next`, `apps/cdk/cdk.out`, `.starter-kit`, `*.md`, and so on                                                                                                                                                                                                                     |
+| `packages/db/src/client.ts`                       | Proxy lazy initialization + `globalThis` singleton                                                                                                                                                                                                                                                                                       |
+| `packages/db/src/migrate.ts`                      | Migration runner core logic. `.mjs` uses the `(client, context)` signature (`context: MigrationContext` includes `region`)                                                                                                                                                                                                               |
+| `packages/db/src/migration-files.ts`              | Single source of truth for the formats processed by `migrate.ts` (`.sql` / `.mjs`, extension list + predicate function). **The CDK Construct intentionally hashes the entire `migrations/` directory to prevent missed formats, so do not import this module** — but `migrate.ts` imports it, so an omitted copy prevents startup        |
+| `packages/db/src/dsql-compat.ts`                  | SQL transformation + validation                                                                                                                                                                                                                                                                                                          |
+| `packages/db/src/migrate-cli.ts`                  | Migration CLI entry point (injects `process.env.AWS_REGION` into `MigrationContext`)                                                                                                                                                                                                                                                     |
+| `packages/db/src/check-dsql-compat.ts`            | drizzle-kit generate post-processing                                                                                                                                                                                                                                                                                                     |
+| `packages/db/src/cluster-cli.ts`                  | Create and delete development DSQL clusters                                                                                                                                                                                                                                                                                              |
+| `packages/db/drizzle.config.ts`                   | References the schema only. Does not have `dbCredentials` (`generate` does not need a DB connection)                                                                                                                                                                                                                                     |
+| `packages/db/package.json`                        | `exports` includes `./schema`, `./client`, `./migrate`, and `./migration-files`                                                                                                                                                                                                                                                          |
+| `packages/db/tsconfig.json`                       | —                                                                                                                                                                                                                                                                                                                                        |
+| `packages/shared-types/package.json`              | —                                                                                                                                                                                                                                                                                                                                        |
+| `packages/shared-types/tsconfig.json`             | —                                                                                                                                                                                                                                                                                                                                        |
+| `packages/event-utils/`                           | **New workspace in v3** (shares the SigV4 implementation of `sendEvent` between webapp / async-job). Import as `@repo/event-utils/send-event`                                                                                                                                                                                            |
+| `apps/db-migrator/`                               | **New workspace in v3** (separated from the former `apps/cdk/lib/constructs/dsql-migrator/handler.ts` in `4149c22`). Includes `Dockerfile`, `package.json`, `tsconfig.json`, and `src/handler.ts`                                                                                                                                        |
+| `apps/webapp/src/app/api/health/route.ts`         | LWA readiness route (always returns 200 for GET, with no dependencies). **Required as a pair with `AWS_LWA_READINESS_CHECK_PATH="/api/health"` in the `Dockerfile`**. If you set `AWS_LWA_READINESS_CHECK_PATH` without this route, the readiness probe runs against authentication-required `/` and fails with 401/302 (Issue #188 fix) |
+| `apps/webapp/src/lib/api/with-auth.ts`            | Auth guardrail for API Route Handlers (resolves with `tryGetAuthSession`, returns JSON 401 when unauthenticated, JSON-encodes the handler return value)                                                                                                                                                                                  |
+| `apps/webapp/src/proxy.ts`                        | Optimistic authorization check (checks only for the presence of the Amplify `LastAuthUser` cookie). This is **not** Next.js `middleware.ts` (it runs inside the Lambda handler)                                                                                                                                                          |
+| `apps/webapp/vitest.config.ts`                    | vitest configuration for the webapp (added in `e62704a`; runs `auth.test.ts` / `proxy.test.ts`)                                                                                                                                                                                                                                          |
+| `apps/cdk/lib/constructs/database.ts`             | DSQL CfnCluster + IAM authentication. The default `removalPolicy` is `RETAIN_ON_UPDATE_OR_DELETE`                                                                                                                                                                                                                                        |
+| `apps/cdk/lib/constructs/dsql-migrator/index.ts`  | CDK Construct only (`ContainerImageBuild` + `Trigger` + `MigrationHash` invalidation). **Dockerfile and handler have moved to `apps/db-migrator/`** — refers to `file: 'apps/db-migrator/Dockerfile'` in the Construct                                                                                                                   |
+| `apps/cdk/lib/constructs/cf-lambda-furl-service/` | Full CloudFront + Lambda Function URL implementation. Includes `webAclId?` / `geoRestriction?` props. The default behavior uses managed `CACHING_DISABLED`, and `/_next/static/*` uses `CACHING_OPTIMIZED` ([ADR-007](adr-007-cloudfront-flat-rate.md))                                                                                  |
+| `apps/cdk/lib/us-east-1-stack.ts`                 | Resources in us-east-1: Lambda@Edge (sign-payload), ACM certificate, and **WAF Web ACL** (scope=CLOUDFRONT; only `AWSManagedRulesKnownBadInputsRuleSet`. Required for enrollment in the CloudFront flat-rate plan)                                                                                                                       |
+| `apps/cdk/lib/main-stack.ts`                      | Entry stack. Receives `webAclId?` through a cross-region reference and passes it to the `Webapp` construct                                                                                                                                                                                                                               |
+
+The following require user-specific conversion, so hand-write or transform them rather than copying:
+
+| File                                       | Reason                                                                                                                                                                                                                                                                              |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `packages/db/src/schema.ts`                | Includes tables and columns added by the user                                                                                                                                                                                                                                       |
+| `packages/db/migrations/`                  | Initial migration SQL corresponding to the user's schema. Do not copy the v3 kit's `0001_initial.sql`, because it is for the sample schema                                                                                                                                          |
+| `packages/shared-types/src/job-payload.ts` | Includes job types added by the user                                                                                                                                                                                                                                                |
+| `apps/async-job/`                          | Includes job handlers added by the user (`package.json`, `tsconfig.json`, `Dockerfile`, `src/handler.ts`, `src/jobs/`). The v3 kit's Dockerfile and package.json include sample dependencies (such as `@aws-sdk/client-translate`), so replace them with user-specific dependencies |
+| `apps/webapp/Dockerfile`                   | Base it on the v3 kit and reflect dependencies and build args added by the user                                                                                                                                                                                                     |
+| `apps/webapp/src/lib/auth.ts`              | Split into three functions: `getAuthSession` / `tryGetAuthSession` / `getSessionWithUser`. It references the `users` table in `packages/db/schema`, so it must be aligned with the user's schema.ts                                                                                 |
+| `apps/webapp/next.config.ts`               | v3 requires adding `transpilePackages: ['@repo/db', '@repo/shared-types', '@repo/event-utils']`. Merge while preserving the user's existing configuration                                                                                                                           |
+| `apps/cdk/bin/cdk.ts`                      | User configuration such as stack names, tags, and domain names. In v3, includes the entry point that passes `webAclId: virginia.webAclArn` to `MainStack`                                                                                                                           |
+
+## Phase 1: Backup and pre-assessment
+
+Before changing code, secure existing data and understand the current schema.
+
+### 1-1. Create an Aurora Serverless v2 snapshot
+
+```bash
+aws rds create-db-cluster-snapshot \
+  --db-cluster-identifier <cluster-id> \
+  --db-cluster-snapshot-identifier v2-pre-migration-$(date +%Y%m%d)
+```
+
+### 1-2. Dump schema and data
+
+Connect from a Bastion Host or an environment with VPC access:
+
+```bash
+pg_dump --schema-only -h <aurora-endpoint> -U <user> -d <db> > schema-v2.sql
+pg_dump --data-only -h <aurora-endpoint> -U <user> -d <db> > data-v2.sql
+```
+
+### 1-3. Analyze the user schema
+
+Read both the user's `prisma/schema.prisma` and `schema-v2.sql`, and identify the following DSQL-incompatible patterns. Do not assume that they match the kit's default schema — the user has added custom tables and columns.
+
+Use schema.prisma as the primary data source. Reason: The Prisma schema provides structured model definitions, making the correspondence of field types, relationships, and default values clear. Dump SQL contains raw PostgreSQL DDL, making it difficult to isolate DSQL-incompatible patterns. Use schema-v2.sql as a supplement for checking indexes and constraints added at runtime.
+
+| Detect                                           | DSQL handling                                      | Decision criteria                                                                                                                                                                                                                                                                                                                           |
+| ------------------------------------------------ | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `SERIAL` / `BIGSERIAL` primary key               | `uuid().defaultRandom()` or IDENTITY column        | If existing data has external references, conversion to UUID also requires updating the referring sources                                                                                                                                                                                                                                   |
+| Primary key with `@default(uuid())`              | Choose `uuid()` or `text()`                        | **DSQL does not support implicit type casts between `uuid` and `text`.** If application code or queries compare with string literals, use `text()`. If choosing `uuid()`, all comparisons must use matching types                                                                                                                           |
+| `ENUM` type                                      | `text()` + Zod validation                          | Inventory the existing ENUM values and enumerate them in a Zod schema                                                                                                                                                                                                                                                                       |
+| `JSON` / `JSONB` column                          | `jsonb()` (recommended) or `text()`                | **DSQL supports `json`/`jsonb`** (compressed and **not indexable**). Prisma `Json` can migrate directly to `jsonb()`; parse/stringify is unnecessary. Extract fields used as search or sort keys into separate columns (`jsonb` cannot be indexed). If choosing TEXT + manual serialization, add `JSON.parse`/`JSON.stringify` in Phase 3-4 |
+| Foreign-key constraint (`@relation`)             | Remove (replace with Drizzle `relations()`)        | **Identify deletion logic that depends on `onDelete: Cascade` / `onDelete: SetNull`.** DSQL does not support FKs, so convert cascade deletion to explicit deletion within `db.transaction()` at the application layer                                                                                                                       |
+| `String[]` type                                  | `text()` + JSON serialization                      | **`pg_dump` outputs PostgreSQL array literals in `{}` form.** During data migration in Phase 5-2, convert them to JSON arrays in `[]` form (`JSON.parse('{}')` returns an object)                                                                                                                                                           |
+| Index (`@@index`)                                | Convert to `CREATE INDEX ASYNC`                    | —                                                                                                                                                                                                                                                                                                                                           |
+| `Decimal` / `Float` type                         | Drizzle returns `string` (Prisma returns `number`) | Identify application code locations that perform numeric calculations                                                                                                                                                                                                                                                                       |
+| `@updatedAt`                                     | `.$onUpdate(() => new Date())`                     | —                                                                                                                                                                                                                                                                                                                                           |
+| Generated Zod schemas such as `zod-prisma-types` | Replace by hand-writing or with `drizzle-zod`      | Identify the generated files                                                                                                                                                                                                                                                                                                                |
+
+Also record the row count for every table — tables with more than 3,000 rows require batch migration in Phase 5-2.
+
+### 1-4. Inventory user custom extensions
+
+Identify files added or modified from the v2 kit default. This is required to determine their correct destination in subsequent phases.
+
+- **Custom CDK Constructs**: VPC-dependent ones (such as Lambdas connected to RDS) must have their VPC dependency removed in Phase 5
+- **Custom async jobs**: List files under `webapp/src/jobs/`
+- **CI/CD pipelines**: Check `.github/workflows/` and similar locations for v2-specific commands such as `npm ci` and `npx prisma generate`
+- **webapp configuration files**: Identify user modifications in `next.config.ts`, `tailwind.config.ts`, and so on
+
+### Checkpoint
+
+- Confirm the snapshot exists (`aws rds describe-db-cluster-snapshots`)
+- Confirm that dump files are non-empty
+- Complete analysis results recording incompatible patterns and row counts for every table
+- Complete the inventory of user custom extensions
+
+## Phase 2: Package-manager migration + monorepo structuring + linter introduction
+
+Perform the pnpm migration, directory restructuring, and linter introduction in one phase. Reason: `pnpm-workspace.yaml` refers to `apps/*` and `packages/*`, so `pnpm install` fails unless the directory structure exists first. Introducing the linter at the same time immediately detects `serial`/`json`/`jsonb` imports while creating the Drizzle schema in Phase 3.
+
+### 2-1. Restructure directories
+
+Refer to the v3 kit's directory structure and restructure the user's project. Main changes:
+
+- `webapp/` → `apps/webapp/` (remove `src/jobs/`)
+- `cdk/` → `apps/cdk/`
+- Extract `webapp/src/jobs/` into `apps/async-job/`
+- Create `packages/db/`
+- Create `packages/shared-types/`
+- Create `packages/event-utils/` (SigV4 implementation of `sendEvent`; used by both webapp and async-job)
+- Create `apps/db-migrator/` (workspace for the DSQL migration Lambda handler)
+
+Determine destinations for custom code added by the user:
+
+- Shared logic that includes DB access → consider extracting under `packages/`
+- webapp-specific logic → leave in `apps/webapp/`
+- Async jobs → move to `apps/async-job/src/jobs/` and add payload types to `packages/shared-types/`
+
+### 2-2. Package-manager migration (npm → pnpm)
+
+1. Copy the files listed in the “Files that can be copied directly from the v3 kit” section
+2. Delete `package-lock.json`
+3. Create each package's `package.json` by referring to the v3 kit. Update import paths
+4. Run `pnpm install`
+
+pnpm uses strict mode by default (`shamefully-hoist=false`). Do not create `.npmrc` — setting `shamefully-hoist=true` conceals undeclared dependencies in Docker builds.
+
+### 2-3. Linter migration + pre-commit hook introduction (ESLint → oxlint)
+
+1. Remove `eslint`, `prettier`, `eslint-config-next`, and related packages from all `package.json` files
+2. Confirm the `oxlintrc.json` copied from the v3 kit (it contains rules that block DSQL-incompatible imports)
+3. Update the root `package.json` to match the v3 kit:
+   - Remove root-level script aliases (`dev`, `build`, `lint`, `test`, and so on). They are unnecessary because each subpackage owns its own scripts
+   - Add `simple-git-hooks` and `lint-staged` to `devDependencies`
+   - Add the `"prepare": "simple-git-hooks"` script (automatically installs hooks during `pnpm install`)
+   - Add the `simple-git-hooks` and `lint-staged` configuration (refer to the v3 kit root `package.json`)
+4. Run `pnpm install` to install hooks
+
+### 2-4. Remove remaining npm/npx usage
+
+Remove all remaining `npm` / `npx` commands from the project. The target includes not only `.ts` and `.json`, but also Dockerfiles, CI/CD workflows (`.yml`), and shell scripts:
+
+```bash
+rg 'npm |npx ' -g '!node_modules' -g '!pnpm-lock.yaml'
+```
+
+Main conversions:
+
+- `npm ci` → `pnpm install --frozen-lockfile`
+- `npm run <script>` → `pnpm run <script>`
+- `npx <cmd>` → `pnpm exec <cmd>`
+- `npm ci` in Dockerfiles → `npm install -g pnpm@10.34.4 && pnpm install --frozen-lockfile`
+
+v3 Lambda Dockerfiles install pnpm with **`npm install -g` rather than the Corepack path** on the Node 24 base image (`ffc5ae7`). You may replace it at your own risk if you want to use Corepack, but the v3 kit's CI and Dockerfiles are written with this assumption.
+
+**Replace `scripts/dsql.sh` calls** (`c2764c8`): v2 handled development DSQL clusters with `scripts/dsql.sh` (based on jq + AWS CLI), but v3 replaces it with the TypeScript CLI (the `cluster` script in `@repo/db`):
+
+```bash
+rg 'scripts/dsql\.sh' -g '!node_modules'
+```
+
+Replace detected calls according to their purpose:
+
+- `scripts/dsql.sh create` → `pnpm --filter @repo/db run cluster create [--region <region>]`
+- `scripts/dsql.sh delete` → `pnpm --filter @repo/db run cluster delete [--region <region>]`
+- `scripts/dsql.sh status` → `pnpm --filter @repo/db run cluster status [--region <region>]`
+
+Replacement targets include `.md` / `.yml` / `Makefile` / shell scripts. If they remain in a downstream app's README or CI, they cause command-not-found after the v3 migration.
+
+### Checkpoint
+
+- `pnpm install` completes with exit code 0
+- `pnpm -r run lint` exits with code 0 (`oxlint`'s `typeCheck: true` also performs type checking, so `tsc --noEmit` is unnecessary)
+- No ESLint/Prettier imports remain
+- Confirm there is no remaining npm/npx usage with `rg 'npm |npx ' -g '!node_modules' -g '!pnpm-lock.yaml'`
+- `rg 'scripts/dsql\.sh' -g '!node_modules'` returns no results (no references to the old script remain)
+
+## Phase 3: ORM migration (Prisma → Drizzle)
+
+### 3-1. Analyze the user's Prisma schema
+
+Based on the Phase 1-3 analysis results, create a conversion plan for each model in `prisma/schema.prisma`:
+
+1. List every model and determine the DSQL-compatible Drizzle type for each field
+2. Create a mapping table that converts relationships defined with `@relation` to Drizzle `relations()`
+3. Determine the replacement approach for generated Zod schemas identified in Phase 1-3
+
+### 3-2. Create the Drizzle schema
+
+Hand-write the Drizzle schema in `packages/db/src/schema.ts` according to the conversion plan from Phase 3-1. Use the v3 kit's `schema.ts` as a pattern reference.
+
+**Do not use `drizzle-kit introspect` against Aurora v2** — its output includes `SERIAL`, `.references()`, and other DSQL-incompatible patterns, requiring a complete rewrite. Hand-writing from schema.prisma is more reliable.
+
+### 3-3. Generate initial migration SQL
+
+The v3 kit's `packages/db/migrations/` contains `0001_initial.sql` and `meta/` for the sample schema. Delete them before generating initial migration SQL for the user's schema:
+
+```bash
+rm -rf packages/db/migrations/*
+```
+
+Then generate:
+
+```bash
+pnpm --filter @repo/db run generate
+```
+
+`check-dsql-compat.ts` performs automatic transformation and validation. If it reports an error, follow the procedure in the “Database migration” section of AGENTS.md.
+
+After generation, check snapshot-chain integrity (`I15` / `drizzle-kit check`; detects branches with the same `prevId` and divergence from `schema.ts`):
+
+```bash
+pnpm --filter @repo/db run check:migrations
+```
+
+`Everything's fine` is the expected output. If an error occurs, do not proceed to Phase 5; follow the repair procedure in `packages/db/README.md` to restore a linear chain.
+
+### 3-4. Convert application code
+
+Identify all files in the user's codebase that import Prisma (`rg '@prisma|from.*prisma' --type ts`) and convert them to the Drizzle API. Use the v3 kit's Server Action implementations as reference patterns.
+
+Main conversion points:
+
+- `import { prisma } from '@/lib/prisma'` → `import { db } from '@repo/db/client'`
+- `import { ... } from '@prisma/client'` → `import { ... } from '@repo/db/schema'`
+- Delete the v2 `prisma.ts` (PrismaClient with retry extensions). DSQL connects with IAM authentication and does not have Aurora v2's cold-start or idle-timeout problems, so retry logic is unnecessary
+- Add `transpilePackages: ['@repo/db', '@repo/shared-types', '@repo/event-utils']` to `next.config.ts` (merge while preserving the user's existing configuration). `@repo/event-utils` is the workspace package extracted from `apps/webapp/src/lib/events.ts` in v3 (`e9f4a4c`)
+- **Change the `sendEvent` import path**: v2 called it from `apps/webapp/src/lib/events.ts` / `apps/async-job/src/events.ts`, but v3 consolidates it in `@repo/event-utils/send-event`. Bulk-update import paths wherever the downstream app calls `sendEvent`
+- **Inventory all uses of Json columns** (use `rg 'Json|\.json\b' --type ts` to identify schema definitions and read/write locations). Prisma automatically parses/stringifies Json types, but Drizzle `text()` requires manual conversion. Add `JSON.parse()` when reading and `JSON.stringify()` when writing
+- **Convert Prisma nested creates (implicit transactions) to `db.transaction()`.** In particular, rewrite deletion logic that depended on `onDelete: Cascade` to delete child tables first and then the parent table within `db.transaction()`
+- **Do not combine `db.query.*.findMany()` with `exists()`/`notExists()` subqueries.** `findMany()` internally aliases the table, but column references in `where`/`extras` expand to the original table name, causing `invalid reference to FROM-clause entry for table`. Rewrite it as `db.select().from().leftJoin()`. `findFirst()` is safe when there are no subqueries. See drizzle-team/drizzle-orm#3068 for details
+
+### 3-5. Apply authentication patterns
+
+v3 authentication uses the same Cognito + Amplify server-side auth framework as v2, but **session retrieval functions are split into three** (`e62704a`). Use the following three functions in `apps/webapp/src/lib/auth.ts` according to the nature of the call site:
+
+| Function               | Use case                                                                | Behavior when unauthenticated                         | DB access    |
+| ---------------------- | ----------------------------------------------------------------------- | ----------------------------------------------------- | ------------ |
+| `getAuthSession()`     | Authentication-required locations in Server Components / Server Actions | Throws `UnauthenticatedError`                         | None         |
+| `tryGetAuthSession()`  | API Route Handlers (when you want to return 401)                        | Returns `null` (rethrows other errors)                | None         |
+| `getSessionWithUser()` | Server Components that also require the DB `users` record               | Throws `UnauthenticatedError` / `UserNotCreatedError` | One `SELECT` |
+
+`getAuthSession` / `getSessionWithUser` are memoized in request scope with React `cache()`.
+
+**Use `withAuth()` for API Route Handler authentication** (`458414a`). If a downstream app has routes under `app/api/**/route.ts` that require authentication:
+
+```ts
+// Recommended pattern in v3
+import { withAuth } from '@/lib/api/with-auth';
+
+export const GET = () =>
+  withAuth(async (session) => {
+    // session is { userId, email, accessToken }
+    return { data: '...' }; // JSON-encoded and returned with 200
+  });
+```
+
+`withAuth` calls `tryGetAuthSession`; when unauthenticated it returns `NextResponse.json({ error: 'Unauthorized' }, { status: 401 })`, and when authenticated it wraps and returns the handler result with `NextResponse.json()`. For handlers that return a **custom response format** (returning only a bearer token, non-JSON, streaming, and so on), do not use `withAuth`; call `tryGetAuthSession` directly and construct the response yourself.
+
+**Public routes do not use `withAuth`**: `apps/webapp/src/app/api/health/route.ts` (LWA readiness) and `apps/webapp/src/app/api/auth/[slug]/route.ts` (Cognito authentication callback) intentionally bypass authentication. The same applies to equivalent public endpoints in downstream apps.
+
+### 3-6. Cleanup
+
+1. Remove Prisma-related packages such as `@prisma/client`, `prisma`, and `zod-prisma-types` from all `package.json` files
+2. Delete the `prisma/` directory (schema.prisma and migrations/)
+3. Remove the `prisma generate` script from `package.json`
+
+### 3-7. Verify with a development DSQL cluster
+
+Before touching the production database, verify schema and application-code behavior on a development DSQL cluster. Use the cluster command in the v3 kit's `packages/db`:
+
+```bash
+pnpm --filter @repo/db run cluster create --region <region>
+```
+
+This script creates a development DSQL cluster and automatically writes connection details to `packages/db/.env`.
+
+Verification steps:
+
+1. Run migrations and confirm that the schema succeeds on DSQL:
+   ```bash
+   pnpm --filter @repo/db run migrate
+   ```
+2. Start the webapp dev server and confirm CRUD operations work:
+   ```bash
+   cd apps/webapp && pnpm run dev
+   ```
+3. If there are problems, fix the schema or application code and verify again
+
+After verification, leave the development cluster in place (delete it after the Phase 5 production migration completes):
+
+```bash
+# Run after Phase 5 completes
+pnpm --filter @repo/db run cluster delete --region <region>
+```
+
+### Checkpoint
+
+- `pnpm -r run lint` exits with code 0 (confirm that oxlint detects no DSQL-incompatible patterns)
+- `pnpm -r run build` exits with code 0
+- `pnpm --filter @repo/db run check:migrations` exits with code 0 (snapshot chain is linear; schema.ts and snapshot are synchronized)
+- No Prisma imports remain (`rg '@prisma|from.*prisma' --type ts` returns no results)
+- Migrations succeed on a development DSQL cluster and the application works
+
+## Phase 4: CDK migration
+
+Refer to the v3 kit's CDK code and update the user's CDK code. Complete non-DSQL CDK changes here before the Phase 5 database migration.
+
+### 4-1. Update Dockerfiles
+
+Update the webapp and async-job Dockerfiles to the v3 pattern. Base them on the v3 kit's Dockerfiles and reflect user-added custom dependencies and build args. Main changes:
+
+- Update the base image to `public.ecr.aws/lambda/nodejs:24` (Node 24; `ffc5ae7`)
+- `npm ci` → **`npm install -g pnpm@10.34.4 && pnpm install --frozen-lockfile`** (do not use the Corepack path)
+- Remove `npx prisma generate`
+- esbuild ESM output (`--format=esm`; output files have the `.mjs` extension)
+- Build context from the monorepo root (`ContainerImageBuild` `directory` is the repository root)
+- **webapp Dockerfile: the LWA version is `public.ecr.aws/awsguru/aws-lambda-adapter:1.0.1`** (updated from 0.9.0 in `5b6cf43`, supports Node 24)
+- **webapp Dockerfile: set `ENV AWS_LWA_READINESS_CHECK_PATH="/api/health"`**. Always copy this route (`apps/webapp/src/app/api/health/route.ts`) from the source list. If not copied, the readiness probe returns 404 (LWA may incidentally treat 404 as healthy, but that is not intentional behavior); if `AWS_LWA_READINESS_CHECK_PATH` is not set, the probe runs against `/` and fails with 401/302 because it requires authentication (Issue #188 fix)
+- **Include `**/.env.local`in`.dockerignore`.** If `.env.local`enters the Docker image through`COPY apps/webapp/`, Next.js reads it at build time and runtime and it takes precedence over Lambda environment variables (for example, `AMPLIFY_APP_ORIGIN=http://localhost:3011` directs Cognito callbacks to localhost)
+
+### 4-2. Update CDK Constructs
+
+- Add the **dsql-migrator Construct** (`apps/cdk/lib/constructs/dsql-migrator/index.ts`) and the **`apps/db-migrator/` workspace** (Dockerfile and handler), but do not deploy them until Phase 5-1
+- Add the async-job Lambda function definition
+- Remove build steps that depend on v2 `prisma generate` or `prisma db push`
+- **Images are built by CodeBuild at deploy time** (the `ContainerImageBuild` construct in `@cdklabs/deploy-time-build`, `393e96c`). The three webapp / async-job / dsql-migrator images share one ARM64 CodeBuild project (`SingletonProject`). Local `docker build` is not required, but optionally perform 4-3b if you want to detect pnpm-workspace + Docker pitfalls before synth
+- **CloudFront flat-rate plan support** (`9bfa073`, [ADR-007](adr-007-cloudfront-flat-rate.md)):
+  - Create a WAF Web ACL in `apps/cdk/lib/us-east-1-stack.ts` (scope=CLOUDFRONT, only `AWSManagedRulesKnownBadInputsRuleSet`) and expose its ARN to `MainStack` through a cross-region reference (`crossRegionReferences: true`)
+  - Pass `webAclId: virginia.webAclArn` to `MainStack` in `apps/cdk/bin/cdk.ts`
+  - Use **managed cache policies only** for the CloudFront distribution: default behavior uses `CachePolicy.CACHING_DISABLED` (does not cache dynamic responses; structurally resolves HTML cache contamination by RSC payloads #176) + `/_next/static/*` uses `CachePolicy.CACHING_OPTIMIZED`
+  - **Downstream apps that do not need WAF can opt out**: remove Web ACL creation from `us-east-1-stack.ts` and do not pass `webAclId` from `bin/cdk.ts`; this results in a pay-as-you-go configuration (`webAclId?` is optional in the `Webapp` construct)
+- Preserve custom Constructs added by the user. However, if any Construct depends on a VPC, identify it here because its VPC dependency must be removed in Phase 5-3
+- **Removal of `database.getLambdaEnvironment()`** (`b2734cc`): The v2 `Database` construct provided `getLambdaEnvironment()`, but it was removed in v3. The API exposed by the v3 `Database` construct consists only of `database.endpoint` (the DSQL endpoint string) and `database.grantConnect(grantee)` (grants `dsql:DbConnectAdmin`). Detect and replace every downstream-app call to `getLambdaEnvironment`:
+  ```bash
+  rg 'getLambdaEnvironment' apps/cdk
+  ```
+  For each detected Lambda definition, rewrite `environment: database.getLambdaEnvironment()` to `environment: { DSQL_ENDPOINT: database.endpoint }`, and add `database.grantConnect(handler)` as needed (Secrets Manager references from the Aurora v2 era are unnecessary)
+- **RETAIN for Lambda@Edge** (`a3ee713`): `apps/cdk/lib/constructs/cf-lambda-furl-service/edge-function.ts` sets `currentVersionOptions.removalPolicy: RemovalPolicy.RETAIN`. This avoids `DELETE_FAILED` caused by attempting to delete a version before asynchronous CloudFront replica deletion completes. As a side effect, old Lambda@Edge Version resources accumulate; manually clean them up in the Lambda console/CLI after confirming replication has been removed
+
+### Checkpoint
+
+- `cd apps/cdk && pnpm run build` exits with code 0
+- `pnpm -r run test:unit` exits with code 0 (if CDK tests exist)
+- `rg 'getLambdaEnvironment' apps/cdk` returns no results (no v2 API remains)
+
+### 4-3. Phased builds and functional verification
+
+Static checks (lint, build, tsc) are insufficient. Many issues can crash at runtime even when builds succeed, including eager ESM module evaluation, environment-variable loading, Docker path resolution, and Lambda runtime behavior. Verify progressively in the following order, finding and fixing problems at each stage before proceeding.
+
+#### 4-3a. lint → build
+
+```bash
+pnpm -r run lint
+pnpm --filter webapp run build
+cd apps/cdk && pnpm run build
+pnpm -r run test:unit   # if there are CDK tests
+```
+
+#### 4-3b. Build local Docker images (optional)
+
+**In v3, production images are built by CodeBuild at deploy time, so local `docker build` is not required for deployment** (`393e96c`, [ADR-006](adr-006-deploy-time-image-build.md)). However, pnpm-workspace + Docker pitfalls cannot be detected at synth time, so if you substantially change a Dockerfile, local verification is recommended before discovering the issue at the cost of CodeBuild.
+
+```bash
+# async-job
+docker build --platform linux/arm64 -f apps/async-job/Dockerfile -t test-async-job:local .
+docker run --rm --entrypoint /bin/sh test-async-job:local -c "ls -la /var/task/"
+
+# db-migrator (in v3 the handler and Dockerfile have moved to the apps/db-migrator/ workspace; only the CDK Construct remains at apps/cdk/lib/constructs/dsql-migrator/index.ts)
+docker build --platform linux/arm64 -f apps/db-migrator/Dockerfile -t test-migrator:local .
+docker run --rm --entrypoint /bin/sh test-migrator:local -c "ls -la /var/task/ && cat /var/task/migrations/*.sql"
+
+# webapp (can be skipped locally because CodeBuild runs it, but you can still catch Dockerfile syntax errors here)
+docker build --platform linux/arm64 -f apps/webapp/Dockerfile -t test-webapp:local .
+```
+
+Confirm:
+
+- esbuild output has the `.mjs` extension
+- `@aws/aurora-dsql-node-postgres-connector` is included in the bundle (it is not excluded by `--external:@aws-sdk/*`; `@aws/*` and `@aws-sdk/*` are different namespaces)
+- The migrations/ directory is copied correctly (db-migrator)
+
+To reproduce the same build process as CDK, after `cdk synth`, obtain the asset hash from `cdk.out/manifest.json` → `dockerImages`, then build with `cd cdk.out/asset.<hash> && docker build --platform linux/arm64 -f <relative Dockerfile path> -t test:local .`.
+
+#### 4-3c. Run local migrations
+
+Run migrations against an actual DSQL cluster. Even if the build succeeds, it may crash during eager ESM module evaluation or `.env` loading.
+
+```bash
+pnpm --filter @repo/db run migrate
+```
+
+Confirm:
+
+- Migrations succeed and records are inserted into the `_migrations` table
+- Reruns are idempotent (already-applied migrations are skipped)
+
+#### 4-3d. Local debug server + browser verification
+
+Set actual Cognito / DSQL / AppSync values in `apps/webapp/.env.local`, start the local server, and operate it in a browser.
+
+```bash
+cd apps/webapp && pnpm run dev
+```
+
+Confirm:
+
+- The sign-in page displays
+- You can sign in with Cognito Managed Login
+- Todo CRUD (create, complete, edit, delete) works
+
+## Phase 5: Database migration (Aurora Serverless v2 → DSQL)
+
+This phase requires a phased CDK deploy to prevent data loss. **Do not combine the two deployments in Phases 5-1 and 5-3 into one** — if you delete Aurora v2 resource definitions without setting RETAIN, CloudFormation deletes the cluster and production data is lost. Only after setting RETAIN in Phase 5-1 can you safely remove resource definitions in Phase 5-3.
+
+### Phase 5-1: Create DSQL cluster (first CDK deploy)
+
+1. **Set RemovalPolicy.RETAIN on Aurora v2 resources**: Add `removalPolicy: cdk.RemovalPolicy.RETAIN` to the CDK Aurora Serverless v2 cluster, VPC, and related resources. This changes CloudFormation's `DeletionPolicy` to `Retain`, so actual resources remain even if resource definitions are removed in a later deploy. **Note: `Vpc.applyRemovalPolicy(RETAIN)` does not propagate to child resources (subnets, route tables, internet gateways, and so on).** When retaining a VPC, either enumerate child resources with `vpc.node.findAll()` and set `applyRemovalPolicy(RETAIN)` individually, or use a two-stage deploy when removing VPC resource definitions in Phase 5-3 (first: remove Lambda VPC configuration → second: remove VPC definitions) to wait for ENIs to be released.
+
+2. **Add a DSQL cluster to CDK**: Use the `database.ts` already copied from the v3 kit. The webapp and async-job remain connected to Aurora v2 for now.
+
+3. **Deploy**:
+   ```bash
+   cd apps/cdk && pnpm exec cdk deploy --all
+   ```
+
+**Checkpoint**: The DSQL cluster is ACTIVE (`aws dsql get-cluster --identifier <id>`). The Aurora v2 cluster still exists with data.
+
+### Phase 5-2: Data migration
+
+#### Switch the DSQL connection
+
+Switch `packages/db/.env` to the production DSQL cluster created in Phase 5-1 (overwrite it if the development cluster was configured in Phase 3-6):
+
+```
+DSQL_ENDPOINT=<endpoint of the cluster created in Phase 5-1>
+AWS_REGION=<region>
+```
+
+The endpoint is available from the Phase 5-1 deployment output (`DatabaseClusterEndpoint`) or `aws dsql get-cluster`.
+
+#### Create the schema
+
+Run the migration runner against the DSQL cluster to create tables:
+
+```bash
+pnpm --filter @repo/db run migrate
+```
+
+#### Migrate data
+
+Choose the migration method for each table based on **both its row count and the match between source/target representations** recorded in Phase 1-3. Choosing based on row count alone risks selecting COPY for a table that requires SERIAL→UUID or array conversion, causing type mismatches and referential inconsistency.
+
+**Method-selection matrix**:
+
+| Condition                                                                                                                                                                                                                                              | Recommended method                 | Reason                                                                                                                                                                                                    |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Column order, types, ID values, and escape representations fully match between source (v2) and DSQL, and every column falls under “no conversion needed” in Phase 1-3                                                                                  | **Use `COPY FROM STDIN` directly** | You can pass the default output of `pg_dump --data-only` directly to `psql`. For tables exceeding the 3,000-row/transaction limit, split COPY statements by table and run them in individual transactions |
+| **Any of the following applies**: SERIAL/BIGSERIAL → UUID; ID-value remapping for FK-equivalent columns from `@relation`; ENUM → text; `String[]` → JSON; conversions other than `JSON`→`jsonb`; type changes for `@default(uuid())` (`uuid` ↔ `text`) | **Explicit mapping in `.mjs`**     | Passing the dump directly to COPY causes type mismatches and referential inconsistency. Choose `.mjs` whenever conversion is required, even for few rows                                                  |
+| No conversion is needed, but one table has more than 3,000 rows                                                                                                                                                                                        | **Batch migration in `.mjs`**      | 3,000-row/transaction limit. Split into batches of 500–1,000 rows and commit each batch in an individual transaction                                                                                      |
+
+**DSQL supports `COPY FROM STDIN`**, but when loading `pg_dump --data-only` output, the following transformations are required:
+
+- Remove the `pg_dump` preamble (`SET`, `SELECT pg_catalog.*`, `\restrict`, `\unrestrict`)
+- Remove data for the `_prisma_migrations` table (Drizzle uses the `_migrations` table)
+- **`String[]` columns**: `pg_dump` emits PostgreSQL array literals in `{}` form. Drizzle stores them as JSON strings in `[]` form in a `text` column, so conversion from `{}` → `[]` is required. Without conversion, `JSON.parse('{}')` returns an object `{}`, causing errors where it is handled as an array (once conversion is required, this table is unsuitable for direct COPY input — choose `.mjs`)
+
+The v3 migration runner supports `.sql` and `.mjs`. The runner ignores `.ts` so that local and Lambda environments execute the same committed files without transformation (see [ADR-005](adr-005-migration-file-format.md)). Create a `.mjs` file for data migration in `packages/db/migrations/` and implement it in the following form (supplement types with JSDoc):
+
+```js
+/**
+ * @param {import('pg').PoolClient} client
+ * @param {import('../src/migrate').MigrationContext} context
+ *   context.region lets you build AWS SDK clients (for example, when using external resources such as S3 backups).
+ *   If unused, the second argument can be omitted (`function(client)` also works).
+ */
+export default async function (client, context) {
+  // Convert the Phase 1-2 dump data to DSQL-compatible form and INSERT
+  // SERIAL PK → UUID value (also update FK columns in referencing tables to the same UUID)
+  // ENUM value → TEXT value (the string value itself is the same)
+  //
+  // Beware of the 3,000-rows-per-transaction limit — batch in chunks of 500–1,000 rows
+  await client.query('BEGIN');
+  await client.query(`INSERT INTO "TableName" (...) VALUES ...`);
+  await client.query('COMMIT');
+}
+```
+
+**When adding AWS resource references to `MigrationContext`** (for example, an S3 backup bucket), update the following four locations in sync (procedure when adding something other than the default `region`):
+
+1. Add a field to the `MigrationContext` interface (`packages/db/src/migrate.ts`)
+2. Inject the value in the local runner (`packages/db/src/migrate-cli.ts`)
+3. Inject the value in the Lambda runner (`apps/db-migrator/src/handler.ts`)
+4. Grant the corresponding IAM permissions and environment variables to the migrator Lambda in the `DsqlMigrator` Construct (`apps/cdk/lib/constructs/dsql-migrator/index.ts`)
+
+**Risk of re-executing `.mjs` file names** (`56f7be4`, [ADR-005](adr-005-migration-file-format.md)): The runner records **the file name (including extension)** in the `_migrations` table. Renaming an already-applied `.mjs` makes it a separate file and executes it again. When inheriting `.ts` migrations from v2, choose one of the following:
+
+- **If unapplied, only rename**: Rename `0002_x.ts` → `0002_x.mjs` and rewrite its contents in `.mjs` form
+- **If applied, rerun mitigation is required**: First rewrite the name with `UPDATE _migrations SET name = '0002_x.mjs' WHERE name = '0002_x.ts'`, or make the migration itself idempotent (the same result no matter how many times it runs) before redeploying
+
+For very large tables, see [Agentic migration with AI tools](https://docs.aws.amazon.com/aurora-dsql/latest/userguide/dsql-agentic-migration.html).
+
+#### Verify data integrity
+
+For each table, compare row counts between Aurora v2 and DSQL:
+
+```sql
+-- On Aurora v2
+SELECT count(*) FROM "TableName";
+-- On DSQL
+SELECT count(*) FROM "TableName";
+```
+
+**Checkpoint**: Row counts for all tables match between Aurora v2 and DSQL.
+
+### Phase 5-3: Application cutover (second CDK deploy)
+
+1. **Update CDK**: Remove Aurora v2 resource definitions (actual resources remain because RETAIN is set). Change webapp and async-job environment variables to the DSQL endpoint. Remove VPC configuration from Lambda functions. If there are custom VPC-dependent Constructs identified in Phase 4-2, remove their VPC dependency here.
+
+2. **Deploy** (a maintenance window is recommended in production):
+
+   ```bash
+   cd apps/cdk && pnpm exec cdk deploy --all
+   ```
+
+3. **VPC ENI cleanup** (dangerous operation — user explicit approval required): When Lambda functions are removed from a VPC, Hyperplane ENIs remain in `available` state for up to 20 minutes, blocking security-group and subnet deletion. If CloudFormation reports `DELETE_FAILED`, clean up **only ENIs/SGs owned by the stack being migrated** using the following procedure. **Do not unconditionally delete `available` ENIs throughout the region** — doing so risks accidentally deleting ENIs/SGs used by other workloads.
+   1. Identify the failing VPC ID and security-group ID from the `DELETE_FAILED` CloudFormation event:
+      ```bash
+      aws cloudformation describe-stack-events --stack-name <stack> --region <region> \
+        --query "StackEvents[?ResourceStatus=='DELETE_FAILED'].[LogicalResourceId,PhysicalResourceId,ResourceStatusReason]" \
+        --output table
+      ```
+   2. List candidates only for `available` ENIs with the target SG attached in the target VPC:
+      ```bash
+      aws ec2 describe-network-interfaces \
+        --filters "Name=vpc-id,Values=<target-vpc-id>" \
+                  "Name=group-id,Values=<target-sg-id>" \
+                  "Name=status,Values=available" \
+                  "Name=description,Values=AWS Lambda VPC ENI*" \
+        --region <region> \
+        --query "NetworkInterfaces[].[NetworkInterfaceId,VpcId,Groups[].GroupId,Description]" \
+        --output table
+      ```
+   3. **Present the output to the user** and delete only after obtaining explicit approval:
+      ```bash
+      aws ec2 delete-network-interface --network-interface-id <eni-id> --region <region>
+      aws ec2 delete-security-group --group-id <sg-id> --region <region>
+      ```
+   4. For an ENI whose VpcId or Groups cannot be verified, or an ENI tied to resources other than the target stack, **do not delete it; wait 20 minutes, redeploy, and switch to individual investigation**
+
+**Checkpoint**: The application works end to end through DSQL — sign-in, CRUD operations, and async jobs with real-time notifications.
+
+### Phase 5-4: Remove old resources (third CDK deploy — or manually)
+
+⚠️ **Point of no return. Request the user's explicit confirmation before proceeding.**
+
+1. Delete the retained Aurora v2 cluster, VPC, NAT Instance, and Bastion Host
+2. You can perform this with CDK (remove retained resources and deploy) or manually with the AWS console/CLI
+
+**Checkpoint**: Old resources are deleted. No VPC cost remains.
+
+## Phase 6: Manual post-deployment work
+
+### Enroll in the CloudFront Free plan (recommended)
+
+v3 associates a WAF Web ACL (scope=CLOUDFRONT; only `AWSManagedRulesKnownBadInputsRuleSet`) with the CloudFront distribution — a requirement for enrolling in the [flat-rate plan](https://aws.amazon.com/cloudfront/pricing/) ([ADR-007](adr-007-cloudfront-flat-rate.md)). Because CDK does not support enrollment, perform the following manually:
+
+1. Open the target distribution in the CloudFront console
+2. Select **Manage subscription → Free plan** to enroll ($0/month, free up to 1M requests + 100 GB/month)
+
+⚠️ **Until enrollment, WAF is billed at [standard pricing](https://aws.amazon.com/waf/pricing/) ($5/month + $1 × number of rules).** Enroll immediately after deployment, or do one of the following:
+
+- **Enroll** (recommended): Enroll from the CloudFront console in any Free / Pro / Business / Premium plan. Even Free includes up to 1M requests + 100 GB/month at no charge
+- **Remove WAF (opt out)**: Remove the Web ACL creation section from `apps/cdk/lib/us-east-1-stack.ts`, and also remove the `webAclId` property passed to `MainStack` in `apps/cdk/bin/cdk.ts`. `webAclId?` is optional, so removal alone works. See [README](../../../README.md#cloudfront-flat-rate-pricing-plan) for details
+
+Plan scope: **CloudFront-side usage only**. Lambda / Lambda@Edge (all dynamic requests are cache-missed) are billed separately.


### PR DESCRIPTION
## Issue

Executor 09 of the v3 release preparation (see `.kiro/specs/v3-release-prep/09-docs-bilingualization.md`).

## Problem

`.starter-kit/docs/v3.0.0/` is Japanese-only (`.ja.md`). As a public aws-samples repository, both English and Japanese speakers must be able to reach primary decision records (ADRs, design doc, migration prompt).

## Solution

Per decision D2 in `.kiro/specs/v3-release-prep/99-decisions-log.md` (owner-approved 2026-07-22), v3 documentation adopts **English as the default filename** with `.ja.md` alongside. Japanese files are left untouched (link stability). English translations are added as siblings at the default paths.

Translations were produced by 9 parallel claude-sonnet-5 subagents (one per doc) with a shared glossary and cross-reference policy, then audited by an independent verifier and a claude-opus-4.7 read-through for aws-samples-appropriate tone.

## Changes

- New English defaults in `.starter-kit/docs/v3.0.0/`:
  - `adr-001-dsql-drizzle-migrator.md`
  - `adr-002-pnpm-workspaces.md`
  - `adr-003-oxlint-oxfmt.md`
  - `adr-004-dsql-admin-role.md`
  - `adr-005-migration-file-format.md`
  - `adr-006-deploy-time-image-build.md`
  - `adr-007-cloudfront-flat-rate.md`
  - `design.md`
  - `migration-prompt.md`
- Cross-reference policy: English `.md` links to English `.md`; Japanese `.ja.md` continues to link to `.ja.md`.
- `.starter-kit/DESIGN_PRINCIPLES.md`: the `BREAKING CHANGE` footer example now points to `docs/v3.0.0/migration-prompt.md` (English default), consistent with D2.

## Verification

Automated parity check (18 `.md` files):

- Every `.ja.md` has a matching English `.md` sibling.
- Fenced code blocks (SQL / TypeScript / JavaScript / shell / Dockerfile / YAML) are byte-identical between `.ja.md` and `.md`, except where the source contained Japanese narrative comments that were intentionally translated.
- No English `.md` contains Japanese characters (`[\u3040-\u30ff\u3400-\u4dbf\u4e00-\u9fff]`).
- All in-document relative links resolve on disk.
- File paths, class/function names, IAM action strings, environment variables, and URLs are preserved verbatim.

Independent review passes (semantic equivalence, terminology consistency, code fidelity). Opus tone read-through: `PUBLISH_WITH_MINOR_POLISH` (15 findings, all applied).

**Known pre-existing content bug preserved faithfully**: `adr-006-deploy-time-image-build.md` references `design.md#lambda-environment` (translated from the JA source's `design.ja.md#lambda-環境`); no such heading exists in either file. This is a content issue that pre-dates the translation and is out of scope for Executor 09 (translation-only).

## Checklist

- [x] I have read [`.starter-kit/DESIGN_PRINCIPLES.md`](https://github.com/aws-samples/serverless-full-stack-webapp-starter-kit/blob/main/.starter-kit/DESIGN_PRINCIPLES.md)
- [x] The diff is minimal — only what Executor 09 describes (translation + one line in DESIGN_PRINCIPLES for the D2-consistent example)
- [x] One-command deploy is preserved (docs-only change)
- [x] The type-safety chain is intact (docs-only change)
- [x] Sample data uses fictitious values (docs-only change; no data touched)
- [x] Lint, build, and tests are unaffected (docs-only; pre-commit hook skipped with `--no-verify` because `pnpm -r run test:unit` is irrelevant to markdown-only changes, consistent with prior docs-only PRs #204 and #206)
