### PR TITLE
feat(webapp): add Playwright E2E suite for v3 release verification

### DIFF
--- a/apps/webapp/.gitignore
+++ b/apps/webapp/.gitignore
@@ -41,3 +41,8 @@ next-env.d.ts
 dist
 
 !.env.local.example
+
+# Playwright E2E artifacts
+/e2e/.auth/
+/playwright-report/
+/test-results/

--- a/apps/webapp/e2e/README.md
+++ b/apps/webapp/e2e/README.md
@@ -1,0 +1,63 @@
+# Playwright E2E tests
+
+This suite validates the deployed webapp through CloudFront, Cognito Managed Login, Aurora DSQL, and AppSync Events. It never starts a local Next.js server.
+
+## Prerequisites
+
+```sh
+pnpm install
+pnpm exec playwright install --with-deps chromium # run once
+```
+
+Test runs and cleanup require every variable below except `E2E_USER_POOL_CLIENT_ID`. `E2E_BASE_URL` must not have a trailing slash.
+
+| Variable                  | Description                                                           |
+| ------------------------- | --------------------------------------------------------------------- |
+| `E2E_BASE_URL`            | CloudFront frontend URL, e.g. `https://web.example.com`               |
+| `E2E_USER_POOL_ID`        | Cognito user pool ID                                                  |
+| `E2E_USER_POOL_CLIENT_ID` | Reserved for future use; not consumed by the current suite            |
+| `E2E_AWS_REGION`          | Region containing the Cognito user pool                               |
+| `E2E_USER_A_EMAIL`        | E2E User A email (also used as Cognito username on email-alias pools) |
+| `E2E_USER_A_PASSWORD`     | E2E User A password                                                   |
+| `E2E_USER_B_EMAIL`        | E2E User B email (also used as Cognito username on email-alias pools) |
+| `E2E_USER_B_PASSWORD`     | E2E User B password                                                   |
+
+## Provision and run
+
+The provisioning command uses the default AWS credentials and emits shell exports to stdout. Do not commit or log the generated passwords.
+
+```sh
+eval "$(pnpm run provision:e2e --silent)"
+pnpm run test:e2e
+pnpm run cleanup:e2e
+```
+
+To view the local report after a run:
+
+```sh
+pnpm exec playwright show-report
+```
+
+## Scenarios
+
+Each row is one test file. `E04` covers the full Todo lifecycle (create → edit → toggle status → delete) as a single scenario; `.kiro/specs/v3-release-prep/08-deploy-verification.md` labels the four state transitions inside it as `E04`–`E07` for traceability.
+
+| Scenario                                                    | Spec IDs | File                             |
+| ----------------------------------------------------------- | -------- | -------------------------------- |
+| Health endpoint returns HTTP 200 and plaintext `ok`         | E01      | `tests/health.spec.ts`           |
+| Unauthenticated `/` redirects to `/sign-in`                 | E02      | `tests/unauth-redirect.spec.ts`  |
+| Sign-in via Cognito Managed Login (idempotent on repeat)    | E03      | `tests/sign-in.spec.ts`          |
+| Todo lifecycle (create / edit / toggle status / delete)     | E04–E07  | `tests/todo-lifecycle.spec.ts`   |
+| Async translation delivered via AppSync Events (no reload)  | E08      | `tests/translate.spec.ts`        |
+| Sign-out invalidates access on the current and new contexts | E09      | `tests/sign-out.spec.ts`         |
+| Tenant isolation between two users                          | E10      | `tests/tenant-isolation.spec.ts` |
+
+## Known brittleness
+
+- Cognito Managed Login DOM selectors are not a public AWS contract and may need updating.
+- E08 waits for the AppSync subscription before requesting translation; asynchronous delivery can still take time.
+- Todo deletion uses Playwright's native-dialog handler for the browser `confirm()` prompt.
+
+## CI readiness
+
+The suite is environment-variable driven. User provisioning is a separate script, storage states under `e2e/.auth/` are gitignored, and HTML reports plus failure traces/screenshots/videos are configured for future artifact upload in the #127 workflow.

--- a/apps/webapp/e2e/auth.setup.ts
+++ b/apps/webapp/e2e/auth.setup.ts
@@ -1,0 +1,50 @@
+import { expect, test, type Page } from '@playwright/test';
+import { mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { cognito } from './selectors';
+
+// Serialize the two setup logins: parallel navigations to Cognito Managed Login can race and time out.
+test.describe.configure({ mode: 'serial' });
+
+type User = {
+  email: string;
+  password: string;
+};
+
+const authDirectory = path.join(__dirname, '.auth');
+
+function getUser(label: 'A' | 'B'): User {
+  const email = process.env[`E2E_USER_${label}_EMAIL`];
+  const password = process.env[`E2E_USER_${label}_PASSWORD`];
+
+  if (!email || !password) {
+    throw new Error(`Missing E2E_USER_${label}_EMAIL or E2E_USER_${label}_PASSWORD`);
+  }
+
+  return { email, password };
+}
+
+async function authenticate(page: Page, user: User) {
+  await page.goto('/');
+  await page.getByRole('link', { name: 'Sign in with Cognito' }).click();
+
+  // FRAGILE: Cognito Managed Login DOM is not a public contract. Update if AWS changes the hosted UI. Verify with: npx playwright codegen <cognito-domain>/login?client_id=...&response_type=code&scope=email+openid+profile&redirect_uri=...
+  await page.locator(cognito.usernameInput).fill(user.email);
+  await page.locator(cognito.passwordInput).fill(user.password);
+  await page.locator(cognito.submitButton).click();
+
+  await expect(page.getByRole('link', { name: 'Todo App' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: /Pending Tasks \(\d+\)/ })).toBeVisible();
+}
+
+test('authenticate as User A', async ({ page }) => {
+  mkdirSync(authDirectory, { recursive: true });
+  await authenticate(page, getUser('A'));
+  await page.context().storageState({ path: path.join(__dirname, '.auth/userA.json') });
+});
+
+test('authenticate as User B', async ({ page }) => {
+  mkdirSync(authDirectory, { recursive: true });
+  await authenticate(page, getUser('B'));
+  await page.context().storageState({ path: path.join(__dirname, '.auth/userB.json') });
+});

--- a/apps/webapp/e2e/fixtures.ts
+++ b/apps/webapp/e2e/fixtures.ts
@@ -1,0 +1,37 @@
+import { expect, test as base, type Browser, type BrowserContextOptions, type Page } from '@playwright/test';
+import path from 'node:path';
+
+export type User = {
+  email: string;
+  password: string;
+};
+
+type AuthenticatedFixtures = {
+  loggedInAsUserA: Page;
+  loggedInAsUserB: Page;
+};
+
+export function authStatePath(user: 'userA' | 'userB') {
+  return path.join(__dirname, '.auth', `${user}.json`);
+}
+
+export function newIsolatedContext(browser: Browser, options: BrowserContextOptions = {}) {
+  return browser.newContext({ ...options, baseURL: process.env.E2E_BASE_URL });
+}
+
+export const test = base.extend<AuthenticatedFixtures>({
+  loggedInAsUserA: async ({ browser }, use) => {
+    const context = await newIsolatedContext(browser, { storageState: authStatePath('userA') });
+    const page = await context.newPage();
+    await use(page);
+    await context.close();
+  },
+  loggedInAsUserB: async ({ browser }, use) => {
+    const context = await newIsolatedContext(browser, { storageState: authStatePath('userB') });
+    const page = await context.newPage();
+    await use(page);
+    await context.close();
+  },
+});
+
+export { expect };

--- a/apps/webapp/e2e/helpers.ts
+++ b/apps/webapp/e2e/helpers.ts
@@ -1,0 +1,62 @@
+import { expect, type Locator, type Page } from '@playwright/test';
+
+type TodoInput = {
+  title: string;
+  description: string;
+};
+
+async function countFromHeading(page: Page, name: 'Pending' | 'Completed') {
+  const heading = page.getByRole('heading', { name: new RegExp(`^${name} Tasks \\(\\d+\\)$`) });
+  const text = await heading.textContent();
+  const count = text?.match(/\((\d+)\)/)?.[1];
+
+  if (!count) {
+    throw new Error(`Could not parse ${name.toLowerCase()} todo count from heading: ${text}`);
+  }
+
+  return Number(count);
+}
+
+export function todoCard(page: Page, title: string): Locator {
+  // exact: true prevents a title that is a substring of another title (e.g. `foo` vs `foo-updated`)
+  // from matching the wrong article's accessible name.
+  return page.getByRole('article', { name: title, exact: true });
+}
+
+export async function createTodo(page: Page, { title, description }: TodoInput) {
+  await page.getByRole('button', { name: '+ Add New Todo' }).click();
+  await page.getByLabel('Title').fill(title);
+  await page.getByLabel('Description').fill(description);
+  await page.getByRole('button', { name: 'Create Todo' }).click();
+  await expect(page.getByRole('heading', { name: 'Create New Todo' })).toBeHidden();
+}
+
+export async function deleteTodo(page: Page, title: string, card: Locator = todoCard(page, title)) {
+  await expect(card).toBeVisible();
+
+  const deleteButton = card.getByRole('button', { name: 'Delete', exact: true });
+  page.once('dialog', (dialog) => dialog.accept());
+  await deleteButton.click();
+
+  await expect(card).toBeHidden();
+}
+
+export function getPendingCount(page: Page) {
+  return countFromHeading(page, 'Pending');
+}
+
+export function getCompletedCount(page: Page) {
+  return countFromHeading(page, 'Completed');
+}
+
+export async function waitForPendingCount(page: Page, expected: number) {
+  await expect(page.getByRole('heading', { name: new RegExp(`Pending Tasks \\(${expected}\\)`) })).toBeVisible({
+    timeout: 60_000,
+  });
+}
+
+export async function waitForCompletedCount(page: Page, expected: number) {
+  await expect(page.getByRole('heading', { name: new RegExp(`Completed Tasks \\(${expected}\\)`) })).toBeVisible({
+    timeout: 60_000,
+  });
+}

--- a/apps/webapp/e2e/selectors.ts
+++ b/apps/webapp/e2e/selectors.ts
@@ -1,0 +1,5 @@
+export const cognito = {
+  usernameInput: 'input[name="username"]', // FRAGILE
+  passwordInput: 'input[name="password"]', // FRAGILE
+  submitButton: 'button[type="submit"]', // FRAGILE
+} as const;

--- a/apps/webapp/e2e/tests/health.spec.ts
+++ b/apps/webapp/e2e/tests/health.spec.ts
@@ -1,0 +1,8 @@
+import { expect, test } from '@playwright/test';
+
+test('E01: health endpoint returns plaintext ok', async ({ request }) => {
+  const response = await request.get('/api/health');
+
+  expect(response.status()).toBe(200);
+  expect(await response.text()).toBe('ok');
+});

--- a/apps/webapp/e2e/tests/sign-in.spec.ts
+++ b/apps/webapp/e2e/tests/sign-in.spec.ts
@@ -1,0 +1,33 @@
+import { expect, newIsolatedContext, test } from '../fixtures';
+import { cognito } from '../selectors';
+
+function getUserA() {
+  const email = process.env.E2E_USER_A_EMAIL;
+  const password = process.env.E2E_USER_A_PASSWORD;
+
+  if (!email || !password) {
+    throw new Error('Missing E2E_USER_A_EMAIL or E2E_USER_A_PASSWORD');
+  }
+
+  return { email, password };
+}
+
+test('E03: repeat sign-in for User A is idempotent', async ({ browser }) => {
+  const context = await newIsolatedContext(browser);
+  const page = await context.newPage();
+  const user = getUserA();
+
+  try {
+    await page.goto('/');
+    await page.getByRole('link', { name: 'Sign in with Cognito' }).click();
+    await page.locator(cognito.usernameInput).fill(user.email);
+    await page.locator(cognito.passwordInput).fill(user.password);
+    await page.locator(cognito.submitButton).click();
+
+    await expect(page.getByRole('link', { name: 'Todo App' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Sign Out' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: /Pending Tasks \(\d+\)/ })).toBeVisible();
+  } finally {
+    await context.close();
+  }
+});

--- a/apps/webapp/e2e/tests/sign-out.spec.ts
+++ b/apps/webapp/e2e/tests/sign-out.spec.ts
@@ -1,0 +1,24 @@
+import { expect, newIsolatedContext, test } from '../fixtures';
+
+test('E09: sign-out invalidates access for the current and a new browser context', async ({
+  browser,
+  loggedInAsUserA: page,
+}) => {
+  await page.goto('/');
+  await page.getByRole('link', { name: 'Sign Out' }).click();
+  await expect(page).toHaveURL(/\/sign-in$/);
+  await expect(page.getByRole('heading', { name: 'Todo App' })).toBeVisible();
+
+  await page.goto('/');
+  await expect(page).toHaveURL(/\/sign-in$/);
+
+  const unauthenticatedContext = await newIsolatedContext(browser);
+  const unauthenticatedPage = await unauthenticatedContext.newPage();
+
+  try {
+    await unauthenticatedPage.goto('/');
+    await expect(unauthenticatedPage).toHaveURL(/\/sign-in$/);
+  } finally {
+    await unauthenticatedContext.close();
+  }
+});

--- a/apps/webapp/e2e/tests/tenant-isolation.spec.ts
+++ b/apps/webapp/e2e/tests/tenant-isolation.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test, authStatePath, newIsolatedContext } from '../fixtures';
+import { createTodo, deleteTodo, todoCard } from '../helpers';
+
+test('E10: User B cannot see a todo created by User A', async ({ browser, loggedInAsUserA: userAPage }) => {
+  const title = `e2e-isolation-${Date.now()}`;
+  await userAPage.goto('/');
+  await createTodo(userAPage, { title, description: 'Created by User A for E10.' });
+
+  let userBContext: Awaited<ReturnType<typeof browser.newContext>> | undefined;
+
+  try {
+    userBContext = await newIsolatedContext(browser, { storageState: authStatePath('userB') });
+    const userBPage = await userBContext.newPage();
+    await userBPage.goto('/');
+    await expect(userBPage.getByRole('heading', { name: /Pending Tasks \(\d+\)/ })).toBeVisible();
+    await expect(todoCard(userBPage, title)).not.toBeVisible();
+  } finally {
+    await userBContext?.close();
+    const userATodo = todoCard(userAPage, title);
+    if (await userATodo.isVisible().catch(() => false)) {
+      await deleteTodo(userAPage, title);
+    }
+  }
+});

--- a/apps/webapp/e2e/tests/todo-lifecycle.spec.ts
+++ b/apps/webapp/e2e/tests/todo-lifecycle.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from '../fixtures';
+import { createTodo, deleteTodo, todoCard } from '../helpers';
+
+test('E04: Todo lifecycle (create → edit → complete → delete)', async ({ loggedInAsUserA: page }) => {
+  const createdTitle = `e2e-crud-${Date.now()}`;
+  const updatedTitle = `${createdTitle}-updated`;
+  await page.goto('/');
+
+  try {
+    // E04: create — verify the new card exists and is not yet marked completed.
+    await createTodo(page, { title: createdTitle, description: 'Created by E04-E07.' });
+    await expect(todoCard(page, createdTitle)).toBeVisible();
+    await expect(todoCard(page, createdTitle).getByRole('heading', { name: createdTitle })).not.toHaveClass(
+      /line-through/,
+    );
+
+    // E05: edit — the accessible name of the article updates because it labels the h3.
+    await todoCard(page, createdTitle).getByRole('button', { name: 'Edit', exact: true }).click();
+    await page.getByLabel('Title').fill(updatedTitle);
+    await page.getByRole('button', { name: 'Save', exact: true }).click();
+    await expect(todoCard(page, updatedTitle)).toBeVisible();
+    await expect(todoCard(page, createdTitle)).toBeHidden();
+
+    // E06: toggle status — verify the todo becomes completed via the line-through class.
+    // Use click() not check(): check() waits for the checkbox to reach checked=true, but
+    // revalidatePath('/') from the server action re-renders the page before Playwright can
+    // observe the state, so check() races. The line-through assertion still verifies the
+    // transition, and it is count-independent so parallel specs cannot break it.
+    await todoCard(page, updatedTitle).getByRole('checkbox').click();
+    await expect(todoCard(page, updatedTitle).getByRole('heading', { name: updatedTitle })).toHaveClass(/line-through/);
+
+    // E07: delete — deleteTodo() verifies the card becomes hidden.
+    await deleteTodo(page, updatedTitle);
+  } finally {
+    for (const title of [updatedTitle, createdTitle]) {
+      const card = todoCard(page, title);
+      if (await card.isVisible().catch(() => false)) {
+        await deleteTodo(page, title);
+      }
+    }
+  }
+});

--- a/apps/webapp/e2e/tests/translate.spec.ts
+++ b/apps/webapp/e2e/tests/translate.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from '../fixtures';
+import { createTodo, deleteTodo, todoCard } from '../helpers';
+
+test.setTimeout(150_000);
+
+test('E08: translation event refreshes the page with a translated todo', async ({ loggedInAsUserA: page }) => {
+  const title = `Buy milk from the store ${Date.now()}`;
+  const translatedDescription = page.getByText(new RegExp(`^Translated from: ${title}`));
+  const translatedCard = page.locator('[role="article"]', { has: translatedDescription });
+  let translationObserved = false;
+
+  await page.goto('/');
+
+  try {
+    await createTodo(page, { title, description: 'Created by E08.' });
+    // FIXME: AppSync subscribe() has no observable readiness signal; if flaky on cold start, extend timeout to 10s or add app-side ready indicator.
+    await page.waitForTimeout(5_000);
+    await todoCard(page, title).getByRole('button', { name: 'Translate', exact: true }).click();
+
+    await expect.poll(() => translatedCard.count(), { timeout: 120_000 }).toBeGreaterThan(0);
+    translationObserved = true;
+
+    await deleteTodo(page, title, translatedCard);
+    await deleteTodo(page, title);
+  } finally {
+    if (translationObserved && (await translatedCard.isVisible().catch(() => false))) {
+      await deleteTodo(page, title, translatedCard);
+    }
+
+    const originalTodo = todoCard(page, title);
+    if (await originalTodo.isVisible().catch(() => false)) {
+      await deleteTodo(page, title);
+    }
+    // A job that completes only after the 120-second poll timeout cannot be cleaned via UI; DB cleanup is out of scope.
+  }
+});

--- a/apps/webapp/e2e/tests/unauth-redirect.spec.ts
+++ b/apps/webapp/e2e/tests/unauth-redirect.spec.ts
@@ -1,0 +1,14 @@
+import { expect, newIsolatedContext, test } from '../fixtures';
+
+test('E02: unauthenticated root request redirects to sign-in', async ({ browser }) => {
+  const context = await newIsolatedContext(browser);
+  const page = await context.newPage();
+
+  try {
+    await page.goto('/');
+    await expect(page).toHaveURL(/\/sign-in$/);
+    await expect(page.getByRole('heading', { name: 'Todo App' })).toBeVisible();
+  } finally {
+    await context.close();
+  }
+});

--- a/apps/webapp/package.json
+++ b/apps/webapp/package.json
@@ -8,6 +8,10 @@
     "start": "next start",
     "test:unit": "vitest run --exclude '**/*.integ.test.ts'",
     "test:watch": "vitest --exclude '**/*.integ.test.ts'",
+    "test:e2e": "playwright test",
+    "test:e2e:report": "playwright show-report",
+    "provision:e2e": "tsx scripts/provision-e2e-users.ts",
+    "cleanup:e2e": "tsx scripts/cleanup-e2e-users.ts",
     "format": "oxfmt --write .",
     "format:ci": "oxfmt --check .",
     "lint": "oxlint --config ../../oxlintrc.json --fix .",
@@ -39,13 +43,16 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
+    "@aws-sdk/client-cognito-identity-provider": "3.995.0",
     "@hookform/resolvers": "^5.2.2",
     "@next-safe-action/adapter-react-hook-form": "^1.0.14",
+    "@playwright/test": "1.55.0",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "tailwindcss": "^4",
+    "tsx": "4.19.0",
     "typescript": "^5",
     "vitest": "^3"
   }

--- a/apps/webapp/playwright.config.ts
+++ b/apps/webapp/playwright.config.ts
@@ -1,0 +1,50 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const requiredEnvironmentVariables = [
+  'E2E_BASE_URL',
+  'E2E_USER_POOL_ID',
+  'E2E_AWS_REGION',
+  'E2E_USER_A_EMAIL',
+  'E2E_USER_A_PASSWORD',
+  'E2E_USER_B_EMAIL',
+  'E2E_USER_B_PASSWORD',
+] as const;
+
+for (const name of requiredEnvironmentVariables) {
+  if (!process.env[name]) {
+    throw new Error(`Missing required E2E environment variable: ${name}`);
+  }
+}
+
+const baseURL = process.env.E2E_BASE_URL;
+if (!baseURL) {
+  throw new Error('Missing required E2E environment variable: E2E_BASE_URL');
+}
+
+export default defineConfig({
+  testDir: './e2e/tests',
+  timeout: 90_000,
+  expect: { timeout: 15_000 },
+  outputDir: 'test-results',
+  reporter: [['html', { outputFolder: 'playwright-report', open: 'never' }], ['list']],
+  // Every spec is written to be count-independent (unique titles + card-scoped locators),
+  // so multiple specs can safely mutate the same shared User A concurrently.
+  fullyParallel: true,
+  workers: process.env.CI ? 2 : undefined,
+  use: {
+    baseURL,
+    actionTimeout: 15_000,
+    navigationTimeout: 30_000,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [
+    { name: 'setup', testDir: './e2e', testMatch: /auth\.setup\.ts/ },
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+      dependencies: ['setup'],
+    },
+  ],
+});

--- a/apps/webapp/scripts/cleanup-e2e-users.ts
+++ b/apps/webapp/scripts/cleanup-e2e-users.ts
@@ -1,0 +1,40 @@
+import { AdminDeleteUserCommand, CognitoIdentityProviderClient } from '@aws-sdk/client-cognito-identity-provider';
+
+function requiredEnvironment(name: 'E2E_USER_POOL_ID' | 'E2E_AWS_REGION' | 'E2E_USER_A_EMAIL' | 'E2E_USER_B_EMAIL') {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+async function deleteUser(client: CognitoIdentityProviderClient, userPoolId: string, email: string) {
+  try {
+    // On email-alias pools, Cognito resolves the email to the underlying user.
+    await client.send(new AdminDeleteUserCommand({ UserPoolId: userPoolId, Username: email }));
+    process.stderr.write(`Deleted E2E user ${email}.\n`);
+  } catch (error) {
+    if (error instanceof Error && error.name === 'UserNotFoundException') {
+      process.stderr.write(`E2E user ${email} was already absent.\n`);
+      return;
+    }
+    throw error;
+  }
+}
+
+async function main() {
+  const userPoolId = requiredEnvironment('E2E_USER_POOL_ID');
+  const region = requiredEnvironment('E2E_AWS_REGION');
+  const client = new CognitoIdentityProviderClient({ region });
+
+  await Promise.all([
+    deleteUser(client, userPoolId, requiredEnvironment('E2E_USER_A_EMAIL')),
+    deleteUser(client, userPoolId, requiredEnvironment('E2E_USER_B_EMAIL')),
+  ]);
+}
+
+void main().catch((error: unknown) => {
+  const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
+  process.stderr.write(`Failed to clean up E2E users: ${message}\n`);
+  process.exitCode = 1;
+});

--- a/apps/webapp/scripts/provision-e2e-users.ts
+++ b/apps/webapp/scripts/provision-e2e-users.ts
@@ -1,0 +1,102 @@
+import {
+  AdminCreateUserCommand,
+  AdminDeleteUserCommand,
+  AdminSetUserPasswordCommand,
+  CognitoIdentityProviderClient,
+} from '@aws-sdk/client-cognito-identity-provider';
+import { randomBytes, randomInt } from 'node:crypto';
+
+type E2EUser = {
+  email: string;
+  password: string;
+};
+
+function requiredEnvironment(name: 'E2E_USER_POOL_ID' | 'E2E_AWS_REGION') {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+  return value;
+}
+
+function generatePassword() {
+  const requiredCharacters = ['ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz', '0123456789', '!@#$%^&*_-'];
+  const characters = requiredCharacters.join('');
+  const password = requiredCharacters.map((set) => set[randomInt(set.length)]);
+
+  while (password.length < 12) {
+    password.push(characters[randomInt(characters.length)]);
+  }
+
+  for (let index = password.length - 1; index > 0; index -= 1) {
+    const replacement = randomInt(index + 1);
+    [password[index], password[replacement]] = [password[replacement], password[index]];
+  }
+
+  return password.join('');
+}
+
+function createUser(label: 'a' | 'b'): E2EUser {
+  return {
+    email: `e2e-user-${label}-${randomBytes(4).toString('hex')}@e2e.test`,
+    password: generatePassword(),
+  };
+}
+
+async function createCognitoUser(client: CognitoIdentityProviderClient, userPoolId: string, user: E2EUser) {
+  try {
+    // On email-alias pools (signInAliases: email), passing the email as Username
+    // is the documented pattern: Cognito treats it as an alias for the email attribute.
+    await client.send(
+      new AdminCreateUserCommand({
+        UserPoolId: userPoolId,
+        Username: user.email,
+        MessageAction: 'SUPPRESS',
+        UserAttributes: [
+          { Name: 'email', Value: user.email },
+          { Name: 'email_verified', Value: 'true' },
+        ],
+      }),
+    );
+  } catch (error) {
+    if (!(error instanceof Error) || error.name !== 'UsernameExistsException') {
+      throw error;
+    }
+
+    await client.send(new AdminDeleteUserCommand({ UserPoolId: userPoolId, Username: user.email }));
+    return createCognitoUser(client, userPoolId, user);
+  }
+
+  await client.send(
+    new AdminSetUserPasswordCommand({
+      UserPoolId: userPoolId,
+      Username: user.email,
+      Password: user.password,
+      Permanent: true,
+    }),
+  );
+}
+
+async function main() {
+  const userPoolId = requiredEnvironment('E2E_USER_POOL_ID');
+  const region = requiredEnvironment('E2E_AWS_REGION');
+  const client = new CognitoIdentityProviderClient({ region });
+  const userA = createUser('a');
+  const userB = createUser('b');
+
+  process.stderr.write(`Creating E2E users in ${userPoolId}.\n`);
+  await createCognitoUser(client, userPoolId, userA);
+  await createCognitoUser(client, userPoolId, userB);
+  process.stderr.write('Created two E2E users. Capture the exports below without committing them.\n');
+
+  process.stdout.write(`export E2E_USER_A_EMAIL='${userA.email}'\n`);
+  process.stdout.write(`export E2E_USER_A_PASSWORD='${userA.password}'\n`);
+  process.stdout.write(`export E2E_USER_B_EMAIL='${userB.email}'\n`);
+  process.stdout.write(`export E2E_USER_B_PASSWORD='${userB.password}'\n`);
+}
+
+void main().catch((error: unknown) => {
+  const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
+  process.stderr.write(`Failed to provision E2E users: ${message}\n`);
+  process.exitCode = 1;
+});

--- a/apps/webapp/src/app/(root)/components/TodoItem.tsx
+++ b/apps/webapp/src/app/(root)/components/TodoItem.tsx
@@ -146,7 +146,10 @@ export default function TodoItemComponent({ todo }: TodoItemProps) {
   }
 
   return (
+    // The article role labels each todo for assistive technology and enables scoped E2E locators.
     <div
+      role="article"
+      aria-labelledby={`todo-title-${todo.id}`}
       className={`border p-4 rounded-md shadow-sm mb-4 ${todo.status === TodoItemStatus.COMPLETED ? 'bg-gray-50' : 'bg-white'}`}
     >
       <div className="flex items-start justify-between">
@@ -160,6 +163,7 @@ export default function TodoItemComponent({ todo }: TodoItemProps) {
           />
           <div className="ml-3">
             <h3
+              id={`todo-title-${todo.id}`}
               className={`text-lg font-medium ${todo.status === TodoItemStatus.COMPLETED ? 'line-through text-gray-500' : 'text-gray-900'}`}
             >
               {todo.title}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,7 +131,7 @@ importers:
     dependencies:
       '@aws-amplify/adapter-nextjs':
         specifier: ^1.7.1
-        version: 1.7.2(aws-amplify@6.16.3)(next@16.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+        version: 1.7.2(aws-amplify@6.16.3)(next@16.2.0(@playwright/test@1.55.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
       '@aws-sdk/client-lambda':
         specifier: ^3.995.0
         version: 3.1013.0
@@ -164,10 +164,10 @@ importers:
         version: 0.488.0(react@19.2.4)
       next:
         specifier: ^16.1.6
-        version: 16.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.0(@playwright/test@1.55.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-safe-action:
         specifier: ^7.10.5
-        version: 7.10.8(@sinclair/typebox@0.34.48)(next@16.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76)
+        version: 7.10.8(@sinclair/typebox@0.34.48)(next@16.2.0(@playwright/test@1.55.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -193,12 +193,18 @@ importers:
         specifier: ^3.24.2
         version: 3.25.76
     devDependencies:
+      '@aws-sdk/client-cognito-identity-provider':
+        specifier: 3.995.0
+        version: 3.995.0
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.71.2(react@19.2.4))
       '@next-safe-action/adapter-react-hook-form':
         specifier: ^1.0.14
-        version: 1.0.14(@hookform/resolvers@5.2.2(react-hook-form@7.71.2(react@19.2.4)))(next-safe-action@7.10.8(@sinclair/typebox@0.34.48)(next@16.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76))(next@16.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-hook-form@7.71.2(react@19.2.4))(react@19.2.4)
+        version: 1.0.14(@hookform/resolvers@5.2.2(react-hook-form@7.71.2(react@19.2.4)))(next-safe-action@7.10.8(@sinclair/typebox@0.34.48)(next@16.2.0(@playwright/test@1.55.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76))(next@16.2.0(@playwright/test@1.55.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-hook-form@7.71.2(react@19.2.4))(react@19.2.4)
+      '@playwright/test':
+        specifier: 1.55.0
+        version: 1.55.0
       '@tailwindcss/postcss':
         specifier: ^4
         version: 4.2.2
@@ -214,12 +220,15 @@ importers:
       tailwindcss:
         specifier: ^4
         version: 4.2.2
+      tsx:
+        specifier: 4.19.0
+        version: 4.19.0
       typescript:
         specifier: ^5
         version: 5.9.3
       vitest:
         specifier: ^3
-        version: 3.2.4(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+        version: 3.2.4(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.19.0)(yaml@2.8.3)
 
   packages/db:
     dependencies:
@@ -382,6 +391,10 @@ packages:
 
   '@aws-sdk/client-cognito-identity-provider@3.1013.0':
     resolution: {integrity: sha512-sFifR7SCF8eAg6MKidfEY/TIkI4xtbVR30Dsd8Yq12SKdFxgHHsBaBgJKDJJ9zlATxPvbyp9I3Rnn0W9fMIGRw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-cognito-identity-provider@3.995.0':
+    resolution: {integrity: sha512-IaovlOy4y6ei0MdL4xQMXn2fcKmVCBARuF0n6BRC3evv6Km8PDMXaXnNwij96fRqWojBEc4hhY6rNCR4e33PAQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-cognito-identity@3.1013.0':
@@ -558,6 +571,10 @@ packages:
 
   '@aws-sdk/util-endpoints@3.982.0':
     resolution: {integrity: sha512-M27u8FJP7O0Of9hMWX5dipp//8iglmV9jr7R8SR8RveU+Z50/8TqH68Tu6wUWBGMfXjzbVwn1INIAO5lZrlxXQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/util-endpoints@3.995.0':
+    resolution: {integrity: sha512-aym/pjB8SLbo9w2nmkrDdAAVKVlf7CM71B9mKhjDbJTzwpSFBPHqJIMdDyj0mLumKC0aIVDr1H6U+59m9GvMFw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-endpoints@3.996.5':
@@ -801,6 +818,12 @@ packages:
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
     deprecated: 'Merged into tsx: https://tsx.is'
 
+  '@esbuild/aix-ppc64@0.23.1':
+    resolution: {integrity: sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
@@ -816,6 +839,12 @@ packages:
   '@esbuild/android-arm64@0.18.20':
     resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.23.1':
+    resolution: {integrity: sha512-xw50ipykXcLstLeWH7WRdQuysJqejuAGPd30vd1i5zSyKK3WE+ijzHmLKxdiCMtH1pHz78rOg0BKSYOSB/2Khw==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
@@ -837,6 +866,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.23.1':
+    resolution: {integrity: sha512-uz6/tEy2IFm9RYOyvKl88zdzZfwEfKZmnX9Cj1BHjeSGNuGLuMD1kR8y5bteYmwqKm1tj8m4cb/aKEorr6fHWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-arm@0.25.12':
     resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
     engines: {node: '>=18'}
@@ -852,6 +887,12 @@ packages:
   '@esbuild/android-x64@0.18.20':
     resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.23.1':
+    resolution: {integrity: sha512-nlN9B69St9BwUoB+jkyU090bru8L0NA3yFvAd7k8dNsVH8bi9a8cUAUSEcEEgTp2z3dbEDGJGfP6VUnkQnlReg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
@@ -873,6 +914,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.23.1':
+    resolution: {integrity: sha512-YsS2e3Wtgnw7Wq53XXBLcV6JhRsEq8hkfg91ESVadIrzr9wO6jJDMZnCQbHm1Guc5t/CdDiFSSfWP58FNuvT3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.12':
     resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
@@ -888,6 +935,12 @@ packages:
   '@esbuild/darwin-x64@0.18.20':
     resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.23.1':
+    resolution: {integrity: sha512-aClqdgTDVPSEGgoCS8QDG37Gu8yc9lTHNAQlsztQ6ENetKEO//b8y31MMu2ZaPbn4kVsIABzVLXYLhCGekGDqw==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
@@ -909,6 +962,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.23.1':
+    resolution: {integrity: sha512-h1k6yS8/pN/NHlMl5+v4XPfikhJulk4G+tKGFIOwURBSFzE8bixw1ebjluLOjfwtLqY0kewfjLSrO6tN2MgIhA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.12':
     resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
@@ -924,6 +983,12 @@ packages:
   '@esbuild/freebsd-x64@0.18.20':
     resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.23.1':
+    resolution: {integrity: sha512-lK1eJeyk1ZX8UklqFd/3A60UuZ/6UVfGT2LuGo3Wp4/z7eRTRYY+0xOu2kpClP+vMTi9wKOfXi2vjUpO1Ro76g==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
@@ -945,6 +1010,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.23.1':
+    resolution: {integrity: sha512-/93bf2yxencYDnItMYV/v116zff6UyTjo4EtEQjUBeGiVpMmffDNUyD9UN2zV+V3LRV3/on4xdZ26NKzn6754g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.12':
     resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
@@ -960,6 +1031,12 @@ packages:
   '@esbuild/linux-arm@0.18.20':
     resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
     engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.23.1':
+    resolution: {integrity: sha512-CXXkzgn+dXAPs3WBwE+Kvnrf4WECwBdfjfeYHpMeVxWE0EceB6vhWGShs6wi0IYEqMSIzdOF1XjQ/Mkm5d7ZdQ==}
+    engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
@@ -981,6 +1058,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.23.1':
+    resolution: {integrity: sha512-VTN4EuOHwXEkXzX5nTvVY4s7E/Krz7COC8xkftbbKRYAl96vPiUssGkeMELQMOnLOJ8k3BY1+ZY52tttZnHcXQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.12':
     resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
@@ -996,6 +1079,12 @@ packages:
   '@esbuild/linux-loong64@0.18.20':
     resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
     engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.23.1':
+    resolution: {integrity: sha512-Vx09LzEoBa5zDnieH8LSMRToj7ir/Jeq0Gu6qJ/1GcBq9GkfoEAoXvLiW1U9J1qE/Y/Oyaq33w5p2ZWrNNHNEw==}
+    engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
@@ -1017,6 +1106,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.23.1':
+    resolution: {integrity: sha512-nrFzzMQ7W4WRLNUOU5dlWAqa6yVeI0P78WKGUo7lg2HShq/yx+UYkeNSE0SSfSure0SqgnsxPvmAUu/vu0E+3Q==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.12':
     resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
@@ -1032,6 +1127,12 @@ packages:
   '@esbuild/linux-ppc64@0.18.20':
     resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
     engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.23.1':
+    resolution: {integrity: sha512-dKN8fgVqd0vUIjxuJI6P/9SSSe/mB9rvA98CSH2sJnlZ/OCZWO1DJvxj8jvKTfYUdGfcq2dDxoKaC6bHuTlgcw==}
+    engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
@@ -1053,6 +1154,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.23.1':
+    resolution: {integrity: sha512-5AV4Pzp80fhHL83JM6LoA6pTQVWgB1HovMBsLQ9OZWLDqVY8MVobBXNSmAJi//Csh6tcY7e7Lny2Hg1tElMjIA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.12':
     resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
@@ -1071,6 +1178,12 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-s390x@0.23.1':
+    resolution: {integrity: sha512-9ygs73tuFCe6f6m/Tb+9LtYxWR4c9yg7zjt2cYkjDbDpV/xVn+68cQxMXCjUpYwEkze2RcU/rMnfIXNRFmSoDw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
@@ -1086,6 +1199,12 @@ packages:
   '@esbuild/linux-x64@0.18.20':
     resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.23.1':
+    resolution: {integrity: sha512-EV6+ovTsEXCPAp58g2dD68LxoP/wK5pRvgy0J/HxPGB009omFPv3Yet0HiaqvrIrgPTBuC6wCH1LTOY91EO5hQ==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
@@ -1119,6 +1238,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.23.1':
+    resolution: {integrity: sha512-aevEkCNu7KlPRpYLjwmdcuNz6bDFiE7Z8XC4CPqExjTvrHugh28QzUXVOZtiYghciKUacNktqxdpymplil1beA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/netbsd-x64@0.25.12':
     resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
@@ -1130,6 +1255,12 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.23.1':
+    resolution: {integrity: sha512-3x37szhLexNA4bXhLrCC/LImN/YtWis6WXr1VESlfVtVeoFJBRINPJ3f0a/6LV8zpikqoUg4hyXw0sFBt5Cr+Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
 
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
@@ -1146,6 +1277,12 @@ packages:
   '@esbuild/openbsd-x64@0.18.20':
     resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.23.1':
+    resolution: {integrity: sha512-aY2gMmKmPhxfU+0EdnN+XNtGbjfQgwZj43k8G3fyrDM/UdZww6xrWxmDkuz2eCZchqVeABjV5BpildOrUbBTqA==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
@@ -1179,6 +1316,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.23.1':
+    resolution: {integrity: sha512-RBRT2gqEl0IKQABT4XTj78tpk9v7ehp+mazn2HbUeZl1YMdaGAQqhapjGTCe7uw7y0frDi4gS0uHzhvpFuI1sA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/sunos-x64@0.25.12':
     resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
@@ -1194,6 +1337,12 @@ packages:
   '@esbuild/win32-arm64@0.18.20':
     resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
     engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.23.1':
+    resolution: {integrity: sha512-4O+gPR5rEBe2FpKOVyiJ7wNDPA8nGzDuJ6gN4okSA1gEOYZ67N8JPk58tkWtdtPeLz7lBnY6I5L3jdsr3S+A6A==}
+    engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
@@ -1215,6 +1364,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.23.1':
+    resolution: {integrity: sha512-BcaL0Vn6QwCwre3Y717nVHZbAa4UBEigzFm6VdsVdT/MbZ38xoj1X9HPkZhbmaBGUD1W8vxAfffbDe8bA6AKnQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.25.12':
     resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
@@ -1230,6 +1385,12 @@ packages:
   '@esbuild/win32-x64@0.18.20':
     resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
     engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.23.1':
+    resolution: {integrity: sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg==}
+    engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
@@ -1850,6 +2011,11 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@playwright/test@1.55.0':
+    resolution: {integrity: sha512-04IXzPwHrW69XusN/SIdDdKZBzMfOT9UNT/YiJit/xpy2VuAoB8NHc8Aplb96zsWDddLnbkPL3TsmrS04ZU2xQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@rollup/rollup-android-arm-eabi@4.59.1':
     resolution: {integrity: sha512-xB0b51TB7IfDEzAojXahmr+gfA00uYVInJGgNNkeQG6RPnCPGr7udsylFLTubuIUSRE6FkcI1NElyRt83PP5oQ==}
@@ -2909,6 +3075,11 @@ packages:
     engines: {node: '>=12'}
     hasBin: true
 
+  esbuild@0.23.1:
+    resolution: {integrity: sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
@@ -2994,6 +3165,11 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -3685,6 +3861,16 @@ packages:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
 
+  playwright-core@1.55.0:
+    resolution: {integrity: sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.55.0:
+    resolution: {integrity: sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   postcss@8.4.31:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
@@ -4040,6 +4226,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.19.0:
+    resolution: {integrity: sha512-bV30kM7bsLZKZIOCHeMNVMJ32/LuJzLVajkQI/qf92J2Qr08ueLQvW00PUZGiuLPP760UINwupgUj8qrSCPUKg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
@@ -4241,11 +4432,11 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@aws-amplify/adapter-nextjs@1.7.2(aws-amplify@6.16.3)(next@16.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+  '@aws-amplify/adapter-nextjs@1.7.2(aws-amplify@6.16.3)(next@16.2.0(@playwright/test@1.55.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       aws-amplify: 6.16.3
       aws-jwt-verify: 4.0.1
-      next: 16.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.0(@playwright/test@1.55.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
   '@aws-amplify/analytics@7.0.93(@aws-amplify/core@6.16.1)':
     dependencies:
@@ -4397,6 +4588,50 @@ snapshots:
       '@aws-sdk/util-endpoints': 3.996.5
       '@aws-sdk/util-user-agent-browser': 3.972.8
       '@aws-sdk/util-user-agent-node': 3.973.9
+      '@smithy/config-resolver': 4.4.13
+      '@smithy/core': 3.23.12
+      '@smithy/fetch-http-handler': 5.3.15
+      '@smithy/hash-node': 4.2.12
+      '@smithy/invalid-dependency': 4.2.12
+      '@smithy/middleware-content-length': 4.2.12
+      '@smithy/middleware-endpoint': 4.4.27
+      '@smithy/middleware-retry': 4.4.44
+      '@smithy/middleware-serde': 4.2.15
+      '@smithy/middleware-stack': 4.2.12
+      '@smithy/node-config-provider': 4.3.12
+      '@smithy/node-http-handler': 4.5.0
+      '@smithy/protocol-http': 5.3.12
+      '@smithy/smithy-client': 4.12.7
+      '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
+      '@smithy/util-base64': 4.3.2
+      '@smithy/util-body-length-browser': 4.2.2
+      '@smithy/util-body-length-node': 4.2.3
+      '@smithy/util-defaults-mode-browser': 4.3.43
+      '@smithy/util-defaults-mode-node': 4.2.47
+      '@smithy/util-endpoints': 3.3.3
+      '@smithy/util-middleware': 4.2.12
+      '@smithy/util-retry': 4.2.12
+      '@smithy/util-utf8': 4.2.2
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
+
+  '@aws-sdk/client-cognito-identity-provider@3.995.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.973.25
+      '@aws-sdk/credential-provider-node': 3.972.26
+      '@aws-sdk/middleware-host-header': 3.972.8
+      '@aws-sdk/middleware-logger': 3.972.8
+      '@aws-sdk/middleware-recursion-detection': 3.972.9
+      '@aws-sdk/middleware-user-agent': 3.972.26
+      '@aws-sdk/region-config-resolver': 3.972.10
+      '@aws-sdk/types': 3.973.6
+      '@aws-sdk/util-endpoints': 3.995.0
+      '@aws-sdk/util-user-agent-browser': 3.972.8
+      '@aws-sdk/util-user-agent-node': 3.973.12
       '@smithy/config-resolver': 4.4.13
       '@smithy/core': 3.23.12
       '@smithy/fetch-http-handler': 5.3.15
@@ -5276,6 +5511,14 @@ snapshots:
       '@smithy/util-endpoints': 3.3.3
       tslib: 2.8.1
 
+  '@aws-sdk/util-endpoints@3.995.0':
+    dependencies:
+      '@aws-sdk/types': 3.973.6
+      '@smithy/types': 4.13.1
+      '@smithy/url-parser': 4.2.12
+      '@smithy/util-endpoints': 3.3.3
+      tslib: 2.8.1
+
   '@aws-sdk/util-endpoints@3.996.5':
     dependencies:
       '@aws-sdk/types': 3.973.6
@@ -5559,6 +5802,9 @@ snapshots:
       '@esbuild-kit/core-utils': 3.3.2
       get-tsconfig: 4.13.6
 
+  '@esbuild/aix-ppc64@0.23.1':
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
@@ -5566,6 +5812,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/android-arm64@0.23.1':
     optional: true
 
   '@esbuild/android-arm64@0.25.12':
@@ -5577,6 +5826,9 @@ snapshots:
   '@esbuild/android-arm@0.18.20':
     optional: true
 
+  '@esbuild/android-arm@0.23.1':
+    optional: true
+
   '@esbuild/android-arm@0.25.12':
     optional: true
 
@@ -5584,6 +5836,9 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.18.20':
+    optional: true
+
+  '@esbuild/android-x64@0.23.1':
     optional: true
 
   '@esbuild/android-x64@0.25.12':
@@ -5595,6 +5850,9 @@ snapshots:
   '@esbuild/darwin-arm64@0.18.20':
     optional: true
 
+  '@esbuild/darwin-arm64@0.23.1':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
@@ -5602,6 +5860,9 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.18.20':
+    optional: true
+
+  '@esbuild/darwin-x64@0.23.1':
     optional: true
 
   '@esbuild/darwin-x64@0.25.12':
@@ -5613,6 +5874,9 @@ snapshots:
   '@esbuild/freebsd-arm64@0.18.20':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.23.1':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
@@ -5620,6 +5884,9 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.23.1':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.12':
@@ -5631,6 +5898,9 @@ snapshots:
   '@esbuild/linux-arm64@0.18.20':
     optional: true
 
+  '@esbuild/linux-arm64@0.23.1':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
@@ -5638,6 +5908,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.18.20':
+    optional: true
+
+  '@esbuild/linux-arm@0.23.1':
     optional: true
 
   '@esbuild/linux-arm@0.25.12':
@@ -5649,6 +5922,9 @@ snapshots:
   '@esbuild/linux-ia32@0.18.20':
     optional: true
 
+  '@esbuild/linux-ia32@0.23.1':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
@@ -5656,6 +5932,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-loong64@0.23.1':
     optional: true
 
   '@esbuild/linux-loong64@0.25.12':
@@ -5667,6 +5946,9 @@ snapshots:
   '@esbuild/linux-mips64el@0.18.20':
     optional: true
 
+  '@esbuild/linux-mips64el@0.23.1':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
@@ -5674,6 +5956,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.23.1':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.12':
@@ -5685,6 +5970,9 @@ snapshots:
   '@esbuild/linux-riscv64@0.18.20':
     optional: true
 
+  '@esbuild/linux-riscv64@0.23.1':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
@@ -5694,6 +5982,9 @@ snapshots:
   '@esbuild/linux-s390x@0.18.20':
     optional: true
 
+  '@esbuild/linux-s390x@0.23.1':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
     optional: true
 
@@ -5701,6 +5992,9 @@ snapshots:
     optional: true
 
   '@esbuild/linux-x64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-x64@0.23.1':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
@@ -5718,10 +6012,16 @@ snapshots:
   '@esbuild/netbsd-x64@0.18.20':
     optional: true
 
+  '@esbuild/netbsd-x64@0.23.1':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.4':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.23.1':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.12':
@@ -5731,6 +6031,9 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.23.1':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
@@ -5748,6 +6051,9 @@ snapshots:
   '@esbuild/sunos-x64@0.18.20':
     optional: true
 
+  '@esbuild/sunos-x64@0.23.1':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
@@ -5755,6 +6061,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/win32-arm64@0.23.1':
     optional: true
 
   '@esbuild/win32-arm64@0.25.12':
@@ -5766,6 +6075,9 @@ snapshots:
   '@esbuild/win32-ia32@0.18.20':
     optional: true
 
+  '@esbuild/win32-ia32@0.23.1':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
@@ -5773,6 +6085,9 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.18.20':
+    optional: true
+
+  '@esbuild/win32-x64@0.23.1':
     optional: true
 
   '@esbuild/win32-x64@0.25.12':
@@ -6121,11 +6436,11 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@next-safe-action/adapter-react-hook-form@1.0.14(@hookform/resolvers@5.2.2(react-hook-form@7.71.2(react@19.2.4)))(next-safe-action@7.10.8(@sinclair/typebox@0.34.48)(next@16.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76))(next@16.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-hook-form@7.71.2(react@19.2.4))(react@19.2.4)':
+  '@next-safe-action/adapter-react-hook-form@1.0.14(@hookform/resolvers@5.2.2(react-hook-form@7.71.2(react@19.2.4)))(next-safe-action@7.10.8(@sinclair/typebox@0.34.48)(next@16.2.0(@playwright/test@1.55.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76))(next@16.2.0(@playwright/test@1.55.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react-hook-form@7.71.2(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@hookform/resolvers': 5.2.2(react-hook-form@7.71.2(react@19.2.4))
-      next: 16.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      next-safe-action: 7.10.8(@sinclair/typebox@0.34.48)(next@16.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76)
+      next: 16.2.0(@playwright/test@1.55.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next-safe-action: 7.10.8(@sinclair/typebox@0.34.48)(next@16.2.0(@playwright/test@1.55.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       react-hook-form: 7.71.2(react@19.2.4)
@@ -6287,6 +6602,10 @@ snapshots:
 
   '@oxlint/binding-win32-x64-msvc@1.56.0':
     optional: true
+
+  '@playwright/test@1.55.0':
+    dependencies:
+      playwright: 1.55.0
 
   '@rollup/rollup-android-arm-eabi@4.59.1':
     optional: true
@@ -6909,13 +7228,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.19.0)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.19.0)(yaml@2.8.3)
 
   '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
@@ -7335,6 +7654,33 @@ snapshots:
       '@esbuild/win32-ia32': 0.18.20
       '@esbuild/win32-x64': 0.18.20
 
+  esbuild@0.23.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.23.1
+      '@esbuild/android-arm': 0.23.1
+      '@esbuild/android-arm64': 0.23.1
+      '@esbuild/android-x64': 0.23.1
+      '@esbuild/darwin-arm64': 0.23.1
+      '@esbuild/darwin-x64': 0.23.1
+      '@esbuild/freebsd-arm64': 0.23.1
+      '@esbuild/freebsd-x64': 0.23.1
+      '@esbuild/linux-arm': 0.23.1
+      '@esbuild/linux-arm64': 0.23.1
+      '@esbuild/linux-ia32': 0.23.1
+      '@esbuild/linux-loong64': 0.23.1
+      '@esbuild/linux-mips64el': 0.23.1
+      '@esbuild/linux-ppc64': 0.23.1
+      '@esbuild/linux-riscv64': 0.23.1
+      '@esbuild/linux-s390x': 0.23.1
+      '@esbuild/linux-x64': 0.23.1
+      '@esbuild/netbsd-x64': 0.23.1
+      '@esbuild/openbsd-arm64': 0.23.1
+      '@esbuild/openbsd-x64': 0.23.1
+      '@esbuild/sunos-x64': 0.23.1
+      '@esbuild/win32-arm64': 0.23.1
+      '@esbuild/win32-ia32': 0.23.1
+      '@esbuild/win32-x64': 0.23.1
+
   esbuild@0.25.12:
     optionalDependencies:
       '@esbuild/aix-ppc64': 0.25.12
@@ -7471,6 +7817,9 @@ snapshots:
       path-exists: 4.0.0
 
   fs.realpath@1.0.0: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -8126,9 +8475,9 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next-safe-action@7.10.8(@sinclair/typebox@0.34.48)(next@16.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76):
+  next-safe-action@7.10.8(@sinclair/typebox@0.34.48)(next@16.2.0(@playwright/test@1.55.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@3.25.76):
     dependencies:
-      next: 16.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.0(@playwright/test@1.55.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
     optionalDependencies:
@@ -8140,7 +8489,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.2.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.0(@playwright/test@1.55.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.0
       '@swc/helpers': 0.5.15
@@ -8159,6 +8508,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.0
       '@next/swc-win32-arm64-msvc': 16.2.0
       '@next/swc-win32-x64-msvc': 16.2.0
+      '@playwright/test': 1.55.0
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -8323,6 +8673,14 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
+
+  playwright-core@1.55.0: {}
+
+  playwright@1.55.0:
+    dependencies:
+      playwright-core: 1.55.0
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.4.31:
     dependencies:
@@ -8674,6 +9032,13 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.19.0:
+    dependencies:
+      esbuild: 0.23.1
+      get-tsconfig: 4.13.6
+    optionalDependencies:
+      fsevents: 2.3.3
+
   tsx@4.21.0:
     dependencies:
       esbuild: 0.27.4
@@ -8714,13 +9079,13 @@ snapshots:
       '@types/istanbul-lib-coverage': 2.0.6
       convert-source-map: 2.0.0
 
-  vite-node@3.2.4(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
+  vite-node@3.2.4(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.19.0)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.19.0)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -8756,7 +9121,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
+  vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.19.0)(yaml@2.8.3):
     dependencies:
       esbuild: 0.27.4
       fdir: 6.5.0(picomatch@4.0.3)
@@ -8769,7 +9134,7 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0
-      tsx: 4.21.0
+      tsx: 4.19.0
       yaml: 2.8.3
 
   vite@7.3.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
@@ -8788,11 +9153,11 @@ snapshots:
       tsx: 4.21.0
       yaml: 2.8.3
 
-  vitest@3.2.4(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3):
+  vitest@3.2.4(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.19.0)(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.19.0)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -8810,8 +9175,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
-      vite-node: 3.2.4(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3)
+      vite: 7.3.1(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.19.0)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@20.19.37)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.19.0)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.37


### PR DESCRIPTION
## Summary

Adds a Playwright E2E test suite (`apps/webapp/e2e/`) covering 10 scenarios that validate the deployed CloudFront + Cognito Managed Login + Aurora DSQL + AppSync Events stack end-to-end. This is Executor 08's Deliverable (A) from `.kiro/specs/v3-release-prep/08-deploy-verification.md`.

The suite is **intentionally NOT wired into CI** in this change. File layout, env-var contract, and provisioning script conform to `127-e2e-ci-design-memo.md` so a future workflow (issue #127) can adopt it without modifying the suite itself.

## Scenario coverage

| ID      | Guarantee verified                                                                                | File                                |
| ------- | ------------------------------------------------------------------------------------------------- | ----------------------------------- |
| E01     | `GET /api/health` returns 200 `ok` (LWA readiness)                                                | `tests/01-health.spec.ts`           |
| E02     | Unauthenticated `/` redirects to `/sign-in`                                                       | `tests/02-unauth-redirect.spec.ts`  |
| E03     | Cognito Managed Login → `/auth-callback` (DB user created) → `/`; idempotent on repeat            | `tests/03-signin-flow.spec.ts`      |
| E04–E07 | Create / edit / toggle status (Pending⇄Completed count) / delete with native `confirm()` dialog   | `tests/04-todo-crud.spec.ts`        |
| E08     | Translate button → async job → AppSync Events → translated todo appears **without manual reload** | `tests/05-translate.spec.ts`        |
| E09     | Sign-out invalidates the current context; new context is unauthenticated                          | `tests/06-signout.spec.ts`          |
| E10     | User A's todo not visible to User B (tenant isolation)                                            | `tests/07-tenant-isolation.spec.ts` |

## O7 constraint conformance

| Requirement                                                                     | Status | Evidence                                                                         |
| ------------------------------------------------------------------------------- | ------ | -------------------------------------------------------------------------------- |
| Setup runs UI login once and generates storageState per run                     | met    | `e2e/auth.setup.ts`                                                              |
| No InitiateAuth token API + raw cookie injection                                | met    | Managed Login form fill only                                                     |
| storageState is not committed                                                   | met    | `.gitignore` covers `/e2e/.auth/`                                                |
| A/B users provisioned via `AdminCreateUser` + `AdminSetUserPassword(Permanent)` | met    | `scripts/provision-e2e-users.ts`; email-only pool → generated Username           |
| DB cleanup is omitted (verification stack destroyed after run)                  | met    | UI cleanup only                                                                  |
| E08 uses DOM eventual assertion, 120 s upper bound                              | met    | `05-translate.spec.ts` (`expect.poll` timeout 120 s, `test.setTimeout(150_000)`) |
| Managed Login DOM is fragile; selectors centralized                             | met    | `e2e/selectors.ts` with `FRAGILE` comments                                       |
| No `data-testid` added                                                          | met    | 0 occurrences under `apps/webapp/src/`                                           |
| Target URL / Cognito pool / region are env vars                                 | met    | `playwright.config.ts` fail-fast on missing vars                                 |
| Provisioning script separated from spec code                                    | met    | `apps/webapp/scripts/`                                                           |
| `playwright.config.ts` has trace / report / video                               | met    | HTML report, `retain-on-failure` trace/video, `only-on-failure` screenshot       |
| LOC target 400–550 (guideline)                                                  | met    | 510 LOC (e2e/ + scripts/)                                                        |

## Design decisions worth reviewing

1. **`TodoItem.tsx` a11y addition, not `data-testid`**: The non-editing branch now emits `role="article"` and `aria-labelledby={\`todo-title-${todo.id}\`}`with a matching`id`on the title`<h3>`. This is an accessibility improvement (each todo is a semantically discrete card for assistive tech) that also lets tests scope operations to a single todo via `page.getByRole('article', { name: title })`. O7 forbids `data-testid`; `role`+`aria-labelledby` is not that.
2. **Cognito email-only pool provisioning**: The kit's user pool uses `signInAliases: { username: false, email: true }`. Per AWS docs, `AdminCreateUser` cannot accept `Username` on email/phone-only pools; Cognito generates a UUID-like Username and returns it. The provisioning script omits `Username`, captures `response.User.Username`, and exports it as `E2E_USER_*_USERNAME` for cleanup. The tests themselves keep filling the login form with the email alias, which continues to work.
3. **Manual `browser.newContext()` calls receive `baseURL`**: A `newIsolatedContext(browser, options)` factory in `fixtures.ts` injects `baseURL: process.env.E2E_BASE_URL` into every manually-created context (E02/E03/E09/E10 + the User A/B fixtures). Without this, `page.goto('/')` on manually created contexts fails because `use.baseURL` in `playwright.config.ts` applies only to the built-in `page` fixture.
4. **`workers: 1` (serial)**: Shared User A is used by CRUD, translate, sign-out, and isolation scenarios. Serialization avoids todo-count races across specs. Estimated wall-clock 2.5–6.5 min per O7.
5. **`E2E_USER_POOL_CLIENT_ID` is documented but not required at run time**: Reserved for future workflow use in stack output extraction; keeping it in the env-var contract makes the CI transition smoother.

## Known brittleness

- **Cognito Managed Login DOM** is not a public AWS contract. Selectors in `e2e/selectors.ts` are marked `FRAGILE` with a codegen-based recovery hint.
- **AppSync subscription readiness (E08)** has no observable signal from the app. The test waits 5 seconds after page load before clicking Translate, then polls the DOM for up to 120 s. On very cold AppSync starts the pre-click wait may be insufficient; a `FIXME` comment documents the tuning knob.
- **DB cleanup is out of scope** per O7. Translated copies that arrive after the 120 s poll timeout are not cleaned; the verification stack is destroyed afterward, so this is acceptable.

## Not part of this change

- Any CI workflow registration (`build.yml` is untouched; `test:e2e` is not part of `pnpm -r run test:unit` or `check:ci`)
- The upstream `.starter-kit/ci/` reference implementation for issue #127 (separate follow-up)
- Real-environment run results — will be added as a comment after Executor 08's Phase B execution

## Verification

- `pnpm -r run check:ci` — 0 warnings / 0 errors across all workspaces
- `pnpm -r run test:unit` — cdk (3 suites / 7 tests / 4 snapshots), webapp (4 files / 18 tests), db (55 tests) all pass
- `pnpm install --frozen-lockfile` — lockfile up to date
- `pnpm exec playwright test --list` (with fake env vars) — enumerates the 2 setup tests + 7 scenario specs (E01–E10)

## References

- Executor 08 spec: `.kiro/specs/v3-release-prep/08-deploy-verification.md`
- CI design memo: `.kiro/specs/v3-release-prep/127-e2e-ci-design-memo.md`
- Decision context: `.kiro/specs/v3-release-prep/99-decisions-log.md` O7 and D9
