### PR TITLE
fix(lint): drop non-functional no-restricted-syntax FK guard

### DIFF
--- a/.starter-kit/docs/v3.0.0/adr-003-oxlint-oxfmt.ja.md
+++ b/.starter-kit/docs/v3.0.0/adr-003-oxlint-oxfmt.ja.md
@@ -17,7 +17,8 @@ ESLint + Prettier を oxlint + oxfmt に置き換え。oxlint は必要な `no-r
 設定済みの DSQL 固有ルール:
 
 - `no-restricted-imports`: `drizzle-orm/pg-core` からの `serial`, `smallserial`, `bigserial` をブロック
-- `no-restricted-syntax`: スキーマファイルでの `.references()` 呼び出しをブロック（設定済みだが未動作 — 結果を参照）
+
+DSQL の外部キー禁止は `packages/db/src/dsql-compat.ts` が生成 DDL レイヤーで強制する — ソース構文レベルの lint を採らない理由は「結果」を参照。
 
 ### 却下した代替案
 
@@ -26,5 +27,6 @@ ESLint + Prettier を oxlint + oxfmt に置き換え。oxlint は必要な `no-r
 
 ## 結果
 
-- **`no-restricted-syntax` 未サポート**: oxlint v1.56.0 時点で `no-restricted-syntax` は未実装。`.references()` 呼び出し制限は `oxlintrc.json` に設定済みだが無効。oxlint がサポートを追加した時点で自動的に有効化される。それまでは `check-dsql-compat.ts` の SQL レベルバリデーション（生成 SQL 内の `REFERENCES`/`FOREIGN KEY` 検出）がフォールバック。
+- **`no-restricted-syntax` は未対応で、ネイティブ追加予定もない。** oxlint 1.56（本キットが最初に導入したバージョン）は未知ルール名を黙って受理し、1.74 以降は `Rule 'no-restricted-syntax' not found in plugin 'eslint'` として明示的に拒否する。oxc プロジェクトは新規 Rust 製ルールを追加する予定はないと表明しており、任意 AST 制約は ESLint 互換の JavaScript プラグインで書くのが公式の道である（[oxc.rs/docs/contribute/linter/adding-rules](https://oxc.rs/docs/contribute/linter/adding-rules)）。本キットは JS プラグインを採らない — 守るべき不変条件は「DSQL に FK DDL が到達しないこと」であり、これは生成 SQL の性質であって TypeScript ソースの性質ではない（`foreignKey()` や手書き SQL も同じ禁止 DDL を生成しうる）。
+- **FK 禁止の権威は DDL レイヤーに一本化する。** `packages/db/src/dsql-compat.ts` がマイグレータに渡される全ステートメントから `REFERENCES` / `FOREIGN KEY` を除去し、残っていれば拒否する。回帰保護は `packages/db/src/dsql-compat.test.ts` の `FK1`〜`FK8` で明示カバー: inline `REFERENCES` 除去（`FK1`）、`CONSTRAINT ... FOREIGN KEY` 行除去（`FK2`）、非 `CONSTRAINT` の `FOREIGN KEY` 行除去（`FK3`）、`ON DELETE` / `ON UPDATE` アクションの剥がし（`FK4`）、`validateSql` が残存 `REFERENCES` / `FOREIGN KEY` を検出（`FK5`, `FK6`）、`validateStatement` が `REFERENCES` を throw（`FK7`）、`transform → validate` 全体パスが FK-free で valid になる（`FK8`）。動作しないソース構文レベルのガードを削除することで、「黙って受理される、決して発火しないルール」による誤った安心感を排除する。
 - **ルールエコシステムの縮小**: oxlint は ESLint より少ないルールをサポート。キットのニーズ（Next.js プラグイン、TypeScript、import 制限）にはカバレッジ十分。追加の ESLint ルールが必要なユーザーは oxlint と並行して ESLint を追加可能。

--- a/.starter-kit/docs/v3.0.0/adr-003-oxlint-oxfmt.md
+++ b/.starter-kit/docs/v3.0.0/adr-003-oxlint-oxfmt.md
@@ -17,7 +17,8 @@ Replace ESLint + Prettier with oxlint + oxfmt. oxlint runs the required `no-rest
 Configured DSQL-specific rules:
 
 - `no-restricted-imports`: blocks `serial`, `smallserial`, `bigserial` from `drizzle-orm/pg-core`
-- `no-restricted-syntax`: blocks `.references()` calls in schema files (configured but non-functional — see Consequences)
+
+The DSQL foreign-key ban is enforced by `packages/db/src/dsql-compat.ts` at the generated-DDL layer — see "Consequences" for why the source-level lint approach was dropped.
 
 ### Rejected alternatives
 
@@ -26,5 +27,6 @@ Configured DSQL-specific rules:
 
 ## Consequences
 
-- **`no-restricted-syntax` unsupported**: As of oxlint v1.56.0, `no-restricted-syntax` is unimplemented. The `.references()` call restriction is configured in `oxlintrc.json` but inactive. It is automatically enabled when oxlint adds support. Until then, SQL-level validation in `check-dsql-compat.ts` (detecting `REFERENCES`/`FOREIGN KEY` in generated SQL) is the fallback.
+- **`no-restricted-syntax` is not supported and is not planned.** oxlint accepts unknown rule names silently in 1.56 (the version this kit was originally set up on), and rejects them explicitly from 1.74 onwards (`Rule 'no-restricted-syntax' not found in plugin 'eslint'`). The oxc project has stated it does not plan to add new Rust-native rules — arbitrary-AST constraints are the intended job of ESLint-compatible JavaScript plugins ([oxc.rs/docs/contribute/linter/adding-rules](https://oxc.rs/docs/contribute/linter/adding-rules)). We do not adopt a JS plugin for this: the invariant we care about is that FK DDL never reaches DSQL, and that is a property of the generated SQL, not of the TypeScript source (`foreignKey()` and hand-written SQL are equally valid ways to produce the same forbidden DDL).
+- **FK ban authority lives at the DDL layer.** `packages/db/src/dsql-compat.ts` strips `REFERENCES` and `FOREIGN KEY` from every statement passed to the migrator and rejects any that still contain them. `packages/db/src/dsql-compat.test.ts` covers the regression with dedicated cases `FK1`–`FK8`: inline `REFERENCES` stripping (`FK1`), `CONSTRAINT ... FOREIGN KEY` line removal (`FK2`), non-`CONSTRAINT` `FOREIGN KEY` line removal (`FK3`), `ON DELETE` / `ON UPDATE` action stripping (`FK4`), `validateSql` catching surviving `REFERENCES` / `FOREIGN KEY` (`FK5`, `FK6`), `validateStatement` throwing on residual `REFERENCES` (`FK7`), and the end-to-end `transform → validate` pipeline yielding FK-free valid DDL (`FK8`). Removing the non-functional source-level ban avoids the false sense of safety that a silently-accepted, never-triggered rule provides.
 - **Smaller rule ecosystem**: oxlint supports fewer rules than ESLint. Coverage is sufficient for the kit's needs (Next.js plugin, TypeScript, import restrictions). Users who need additional ESLint rules can add ESLint alongside oxlint.

--- a/oxlintrc.json
+++ b/oxlintrc.json
@@ -31,19 +31,5 @@
       }
     ]
   },
-  "overrides": [
-    {
-      "files": ["**/schema.ts", "**/schema/*.ts"],
-      "rules": {
-        "no-restricted-syntax": [
-          "error",
-          {
-            "selector": "CallExpression > MemberExpression > Identifier[name='references']",
-            "message": "DSQL does not support foreign keys. Use Drizzle relations() instead of .references()."
-          }
-        ]
-      }
-    }
-  ],
   "ignorePatterns": ["node_modules", ".next", "cdk.out", "dist", "*.js", "*.mjs", "*.d.ts"]
 }

--- a/packages/db/src/dsql-compat.test.ts
+++ b/packages/db/src/dsql-compat.test.ts
@@ -187,3 +187,111 @@ describe('validateStatement', () => {
     );
   });
 });
+
+// The DSQL foreign-key invariant is enforced authoritatively here (generated-DDL
+// layer), not at the TypeScript source layer. The kit previously carried a
+// no-restricted-syntax oxlint override that was silently no-op — see ADR-003.
+// These tests lock in the actual guarantees the DDL layer must provide:
+//   (1) transformSql removes every FK generation path from drizzle-kit output,
+//       preserving the column definition itself.
+//   (2) validateSql / validateStatement reject any residual REFERENCES /
+//       FOREIGN KEY that slipped past transformSql (defence-in-depth).
+//   (3) The end-to-end pipeline (transform then validate) accepts drizzle-kit
+//       output that started with an FK and produces FK-free, DSQL-valid DDL.
+describe('dsql-compat: FK / REFERENCES removal (invariants for ADR-003)', () => {
+  test('FK1: transformSql removes inline REFERENCES and preserves the column definition', () => {
+    // Typical shape drizzle-kit emits from `.references(() => users.id)`.
+    const input = [
+      'CREATE TABLE "t" (',
+      '\t"id" text PRIMARY KEY NOT NULL,',
+      '\t"userId" text NOT NULL REFERENCES "users"("id")',
+      ');',
+    ].join('\n');
+
+    const result = transformSql(input);
+
+    expect(result).not.toMatch(/REFERENCES/i);
+    // Column definition itself is preserved.
+    expect(result).toContain('"userId" text NOT NULL');
+  });
+
+  test('FK2: transformSql removes a standalone CONSTRAINT ... FOREIGN KEY line', () => {
+    const input = [
+      'CREATE TABLE "t" (',
+      '\t"id" text PRIMARY KEY NOT NULL,',
+      '\t"userId" text NOT NULL,',
+      '\tCONSTRAINT "t_userId_users_id_fk" FOREIGN KEY ("userId") REFERENCES "users"("id")',
+      ');',
+    ].join('\n');
+
+    const result = transformSql(input);
+
+    expect(result).not.toMatch(/FOREIGN\s+KEY/i);
+    expect(result).not.toMatch(/REFERENCES/i);
+    expect(result).toContain('"userId" text NOT NULL');
+  });
+
+  test('FK3: transformSql removes a FOREIGN KEY line without the CONSTRAINT keyword', () => {
+    // drizzle-kit's `foreignKey()` helper can emit FOREIGN KEY lines without a
+    // preceding CONSTRAINT clause. Covered by a separate regex branch in
+    // dsql-compat.ts; regression tested here.
+    const input = [
+      'CREATE TABLE "t" (',
+      '\t"id" text PRIMARY KEY NOT NULL,',
+      '\t"userId" text NOT NULL,',
+      '\tFOREIGN KEY ("userId") REFERENCES "users"("id")',
+      ');',
+    ].join('\n');
+
+    const result = transformSql(input);
+
+    expect(result).not.toMatch(/FOREIGN\s+KEY/i);
+    expect(result).not.toMatch(/REFERENCES/i);
+  });
+
+  test('FK4: transformSql strips ON DELETE / ON UPDATE actions attached to inline REFERENCES', () => {
+    const input = 'ALTER TABLE "t" ADD COLUMN "userId" text NOT NULL REFERENCES "users"("id") ON DELETE CASCADE;';
+    const result = transformSql(input);
+    expect(result).not.toMatch(/REFERENCES/i);
+    expect(result).not.toMatch(/ON\s+DELETE/i);
+    expect(result).toContain('"userId" text NOT NULL');
+  });
+
+  test('FK5: validateSql flags surviving REFERENCES as DSQL-incompatible', () => {
+    // If a hand-written migration bypasses transformSql (or transformSql regresses),
+    // the post-transform check must still catch REFERENCES so we never send FK DDL
+    // to DSQL.
+    const sql = 'CREATE TABLE "t" (\n\t"userId" text NOT NULL REFERENCES "users"("id")\n);';
+    const errors = validateSql(sql);
+    expect(errors.map((e) => e.pattern)).toContain('REFERENCES');
+  });
+
+  test('FK6: validateSql flags surviving FOREIGN KEY as DSQL-incompatible', () => {
+    const sql = 'CREATE TABLE "t" (\n\tFOREIGN KEY ("userId") REFERENCES "users"("id")\n);';
+    const errors = validateSql(sql);
+    const patterns = errors.map((e) => e.pattern);
+    expect(patterns).toContain('FOREIGN KEY');
+  });
+
+  test('FK7: validateStatement throws on a statement that still contains REFERENCES', () => {
+    const stmt = 'CREATE TABLE "t" (\n\t"userId" text NOT NULL REFERENCES "users"("id")\n);';
+    expect(() => validateStatement(stmt, 'test.sql')).toThrow(/REFERENCES|FOREIGN KEY/i);
+  });
+
+  test('FK8: full generate path (transform then validate) yields FK-free, valid DDL', () => {
+    // End-to-end assertion: drizzle-kit output containing an FK survives
+    // transform + validate to produce zero errors and no FK residue.
+    const generated = [
+      'CREATE TABLE "t" (',
+      '\t"id" text PRIMARY KEY NOT NULL,',
+      '\t"userId" text NOT NULL REFERENCES "users"("id")',
+      ');',
+    ].join('\n');
+
+    const transformed = transformSql(generated);
+    const errors = validateSql(transformed);
+
+    expect(errors).toHaveLength(0);
+    expect(transformed).not.toMatch(/REFERENCES|FOREIGN\s+KEY/i);
+  });
+});

--- a/packages/db/src/schema.integ.test.ts
+++ b/packages/db/src/schema.integ.test.ts
@@ -60,29 +60,4 @@ describe('oxlint DSQL rules', () => {
     const { output } = runOxlint(file);
     expect(output).not.toContain('no-restricted-imports');
   });
-
-  // no-restricted-syntax is not yet supported by oxlint (as of v1.56.0).
-  // The rule is configured in oxlintrc.json for future compatibility.
-  // These tests are skipped until oxlint adds support.
-  // oxlint-disable-next-line jest/no-disabled-tests -- waiting for oxlint no-restricted-syntax support
-  test.skip('L5: .references() detected in schema.ts', () => {
-    const file = writeFile(
-      'schema.ts',
-      [
-        "import { pgTable, text } from 'drizzle-orm/pg-core';",
-        "const users = pgTable('users', { id: text('id').primaryKey() });",
-        "const t = pgTable('t', { userId: text('userId').references(() => users.id) });",
-        '',
-      ].join('\n'),
-    );
-    const { output } = runOxlint(file);
-    expect(output).toContain('no-restricted-syntax');
-  });
-
-  // oxlint-disable-next-line jest/no-disabled-tests -- waiting for oxlint no-restricted-syntax support
-  test.skip('L6: .references() not detected in non-schema file', () => {
-    const file = writeFile('actions.ts', "const x = { references: () => 'ok' };\nx.references();\n");
-    const { output } = runOxlint(file);
-    expect(output).not.toContain('no-restricted-syntax');
-  });
 });


### PR DESCRIPTION
## Issue

Closes #230.

## Problem

`oxlintrc.json` の `**/schema.ts` override に `.references()` を禁止する目的で `no-restricted-syntax` が入っていたが、実際には一度も発火していない。

- **oxlint 1.56.0** (`oxlint --rules`) には `no-restricted-syntax` が存在しない。未知のルール名は黙って受理されるだけで実行されない。`.references()` を含む `schema.ts` 相当ファイルを lint しても `Found 0 warnings and 0 errors`。
- **oxlint 1.74+** は明示的に拒否する: `Rule 'no-restricted-syntax' not found in plugin 'eslint'`。
- oxc プロジェクトは [新規 Rust 製ルールを追加する予定はないと表明](https://oxc.rs/docs/contribute/linter/adding-rules)しており、任意 AST 制約は ESLint 互換の JavaScript プラグインで実装するのが公式の道。よって `schema.integ.test.ts` の「waiting for oxlint no-restricted-syntax support」コメントの前提は誤っている。

対になる 2 テストは `test.skip` で「oxlint 対応待ち」とされていたが、この待ちは恒久的に解消しない。

## Solution

JS プラグインを導入して塗り潰すのではなく、動作しないガード自体を落とす。同時に「FK 禁止の権威は `dsql-compat.ts`（生成 DDL レイヤー）」という主張を、リグレッションテスト 8 件で機械的に protectable にする。

守るべき不変条件は「DSQL に FK DDL が到達しないこと」であり、これは生成 SQL の性質であって TypeScript ソースの性質ではない（`foreignKey()` や手書き SQL も同じ禁止 DDL を生成しうる）。`dsql-compat.ts` は transform 側で `REFERENCES` / `FOREIGN KEY` を除去し、validate 側で残存を拒否する二段構えを既に持っている。既存テストは `T5` / `T6`（inline / CONSTRAINT の 2 経路）しか押さえていなかったので、他の経路（非 CONSTRAINT の `FOREIGN KEY` / `ON DELETE`・`ON UPDATE` アクション / `validateSql` の leak-detection / `validateStatement` の throw / end-to-end pipeline）を明示的にカバーする。

## Changes

- **`oxlintrc.json`** — `**/schema.ts` の `no-restricted-syntax` override を削除。DSQL の serial 禁止（`no-restricted-imports`）は残る。
- **`packages/db/src/schema.integ.test.ts`** — `test.skip` されていた 2 ケース（L5, L6）と「waiting for oxlint no-restricted-syntax support」の前置きコメントを削除。
- **`packages/db/src/dsql-compat.test.ts`** — 回帰テスト 8 件（`FK1`〜`FK8`）を追加し、FK 除去の各経路と end-to-end pipeline をロック（詳細は Verification）。
- **`.starter-kit/docs/v3.0.0/adr-003-oxlint-oxfmt.md`** / **`.ja.md`** — Consequences セクションを修正。`no-restricted-syntax` は未対応かつ _追加予定なし_ である旨（oxc-project の一次ソース付き）と、FK 禁止の権威が DDL レイヤーにあり、`FK1`〜`FK8` の各ケースで具体的にどの経路が保護されているかを明記。

## Verification

```sh
pnpm -r run check:ci     # 7 packages, 0 warnings / 0 errors
pnpm -r run test:unit    # cdk 3 suites/7 tests, webapp 4 files/18 tests, db 2 files/64 tests
cd apps/cdk && pnpm exec cdk synth  # 両 stack が clean synthesise
```

追加した FK リグレッションテスト（`packages/db/src/dsql-compat.test.ts`）の内訳:

- `FK1`: `transformSql` が inline `REFERENCES` を除去し、列定義（`"userId" text NOT NULL`）は保持する。
- `FK2`: `transformSql` が `CONSTRAINT ... FOREIGN KEY` 行（drizzle-kit の主経路）を丸ごと除去する。
- `FK3`: `transformSql` が `CONSTRAINT` キーワードなしの `FOREIGN KEY` 行（`foreignKey()` ヘルパ経由の別経路）を除去する。
- `FK4`: `transformSql` が inline `REFERENCES` に付随する `ON DELETE CASCADE` / `ON UPDATE` アクションも一緒に除去する。
- `FK5`: `validateSql` が transform を経ずに残った `REFERENCES` を DSQL-incompatible として検出する。
- `FK6`: `validateSql` が残存 `FOREIGN KEY` を検出する。
- `FK7`: `validateStatement` が `REFERENCES` を含む statement で throw する。
- `FK8`: end-to-end — drizzle-kit 生成 SQL が `transform → validate` を通過して FK-free / エラーなしの DSQL 互換 DDL になる。

**protection check**: `transformSql` の inline `REFERENCES` 除去行を一時的にコメントアウトしたところ `FK1` / `FK4` / `FK8`（および既存の `T8` composite と migrate.ts の `M7a`）が失敗し、テストが実際にリグレッションを捕捉することを確認した。復元後は全 64 tests pass。

現行の `packages/db/src/schema.ts` は `relations()` を使っており、`.references()` メソッド呼び出しは存在しない。`one({ references: [users.id] })` の `references:` はコンフィグオブジェクトのプロパティキーであってメソッド呼び出しではないため、今回の変更で影響しない。

## Checklist

- [x] I have read [`.starter-kit/DESIGN_PRINCIPLES.md`](https://github.com/aws-samples/serverless-full-stack-webapp-starter-kit/blob/main/.starter-kit/DESIGN_PRINCIPLES.md)
- [x] The diff is minimal — only what the linked issue describes
- [x] One-command deploy is preserved (`pnpm exec cdk deploy --all` remains the only deployment step)
- [x] The type-safety chain (Drizzle → Zod → Server Actions → React) is intact
- [x] Sample data uses fictitious values (AnyCompany, example.com, 192.0.2.0/24, amzn-s3-demo-bucket)
- [x] Lint, build, and tests pass locally (commands in [`AGENTS.md`](https://github.com/aws-samples/serverless-full-stack-webapp-starter-kit/blob/main/AGENTS.md))
