### PR TITLE
docs: complete the 3.0.0 breaking-changes section in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,16 @@
 
 ### ⚠ BREAKING CHANGES
 
+* v2-derived apps require a whole-substrate migration. Repository layout, database engine, ORM, linter/formatter, and package manager all change. See .starter-kit/docs/v3.0.0/migration-prompt.md.
+* .ts migrations no longer run. Rename to .mjs and either update _migrations.name or make each migration idempotent. See .starter-kit/docs/v3.0.0/adr-005-migration-file-format.md.
 * CloudFront distribution replaces custom cache policy with managed policies and now requires a WAF Web ACL. Manual Free-plan enrollment is required to avoid WAF charges. See README section 4 and .starter-kit/docs/v3.0.0/adr-007-cloudfront-flat-rate.md.
 
 ### Features
 
 * **cdk:** expose removalPolicy and deletionProtection on the Auth construct ([#184](https://github.com/aws-samples/serverless-full-stack-webapp-starter-kit/issues/184)) ([c8552e1](https://github.com/aws-samples/serverless-full-stack-webapp-starter-kit/commit/c8552e16e0eb72bfed2059d02801736155e12966))
+* **cdk:** support CloudFront flat-rate pricing plans with managed cache policies and us-east-1 WAF Web ACL — migration guide: README section 4 and .starter-kit/docs/v3.0.0/adr-007-cloudfront-flat-rate.md ([c8552e1](https://github.com/aws-samples/serverless-full-stack-webapp-starter-kit/commit/c8552e16e0eb72bfed2059d02801736155e12966))
 * migrate to pnpm workspaces monorepo with Aurora DSQL and Drizzle ORM — migration guide: .starter-kit/docs/v3.0.0/migration-prompt.md ([c8552e1](https://github.com/aws-samples/serverless-full-stack-webapp-starter-kit/commit/c8552e16e0eb72bfed2059d02801736155e12966))
+* standardize DSQL migrations on .sql/.mjs and harden re-run detection — migration guide: .starter-kit/docs/v3.0.0/adr-005-migration-file-format.md ([c8552e1](https://github.com/aws-samples/serverless-full-stack-webapp-starter-kit/commit/c8552e16e0eb72bfed2059d02801736155e12966))
 * **webapp:** add withAuth() API Route authentication helper and migrate cognito-token ([#186](https://github.com/aws-samples/serverless-full-stack-webapp-starter-kit/issues/186)) ([c8552e1](https://github.com/aws-samples/serverless-full-stack-webapp-starter-kit/commit/c8552e16e0eb72bfed2059d02801736155e12966))
 
 


### PR DESCRIPTION
## Issue

None (release follow-up; orchestration decision O13).

## Problem

release-please parsed the `BEGIN_COMMIT_OVERRIDE` block of #126 correctly for **version computation** (3.0.0) but emitted an incomplete CHANGELOG for 3.0.0: only 1 of 3 breaking changes appeared, and 2 feature entries were dropped. A v2-derived-app owner reading `CHANGELOG.md` in the repo would miss the substrate migration and the `.ts` migration re-execution risk.

## Solution

Restore the missing lines only — generated wording is untouched (4 insertions, 0 deletions). The GitHub Release body already carries the full curated notes; this brings the in-repo CHANGELOG to parity.

## Changes

- ⚠ BREAKING CHANGES: + monorepo/DSQL substrate entry, + .sql/.mjs migration-format entry
- Features: + CloudFront flat-rate entry, + DSQL migration hardening entry

## Verification

- `git diff`: 4 insertions only, existing lines byte-identical
- `docs:` commit type — does not trigger a new release-please PR

## Checklist

- [x] I have read [`.starter-kit/DESIGN_PRINCIPLES.md`](https://github.com/aws-samples/serverless-full-stack-webapp-starter-kit/blob/main/.starter-kit/DESIGN_PRINCIPLES.md)
- [x] The diff is minimal