### PR TITLE
docs: document container and bundle asset constraints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,14 @@ The webapp runs on Lambda behind CloudFront via Lambda Web Adapter (response str
 
 Lambda@Edge function versions (`edge-function.ts`) are retained (`RemovalPolicy.RETAIN`) instead of deleted by CDK, since CloudFront replica deletion is asynchronous and premature deletion causes `DELETE_FAILED`. Retained versions accumulate over deploys and must be deleted manually (via the Lambda console/CLI, after confirming they are no longer replicated to any edge location) if cleanup is needed.
 
+### Container and bundle assets
+
+Both container images are built from the repo root (`directory: join('..', '..')`) with `ignoreMode: IgnoreMode.DOCKER`, so the root `.dockerignore` governs what is staged. Without `IgnoreMode.DOCKER`, CDK applies its own ignore semantics and recursively copies `cdk.out` into the asset staging directory, which fails with `ENAMETOOLONG`.
+
+- The Dockerfiles run `pnpm install` without `--filter`. Under pnpm's strict `node_modules` layout, a filtered install omits transitive dependencies that esbuild needs to resolve while bundling.
+- esbuild emits `.mjs`. The bundle is ESM (`--format=esm`) and the packages do not set `"type": "module"`, so a `.js` extension would be loaded as CJS at Lambda runtime and fail.
+- `--external:@aws-sdk/*` does not match `@aws/*`. `@aws/aurora-dsql-node-postgres-connector` is bundled, not externalized — do not assume the AWS SDK exclusion covers it.
+
 ### Real-time notifications
 
 Server → client push uses AppSync Events. Server-side: `sendEvent(channelName, payload)` with IAM SigV4 signing. Client-side: `useEventBus` hook with Cognito user pool auth. The channel namespace is `event-bus/`.


### PR DESCRIPTION
## Issue

No linked issue. Surfaced while auditing which AGENTS.md lines are load-bearing across this kit and its derivative apps.

## Problem

Four constraints in the container build path are not derivable from reading the code. Each looks like an arbitrary choice until you have hit the failure it prevents, so agents and humans copying the kit re-derive them:

- Omitting `ignoreMode: IgnoreMode.DOCKER` with a repo-root build context makes CDK apply its own ignore semantics and recursively copy `cdk.out` into the asset staging directory. It fails late with an opaque `ENAMETOOLONG`.
- `apps/async-job/Dockerfile` already explains that the builder's `node_modules` is discarded, but not why a filtered install cannot work: under pnpm's strict layout, `--filter` omits transitive dependencies that esbuild must resolve while bundling.
- The `.mjs` output extension is load-bearing. The bundle is `--format=esm` and no package sets `"type": "module"`, so `.js` would be loaded as CJS at Lambda runtime.
- `--external:@aws-sdk/*` does not match `@aws/*`. `@aws/aurora-dsql-node-postgres-connector` is bundled rather than externalized, which is easy to misread when adding new externals.

## Solution

Document them as a `Container and bundle assets` section in the development guide, next to `Lambda environment`. These are "why not" constraints: the documentation policy in AGENTS.md keeps them out of prose that merely restates code, but each of these four lines prevents a concrete mistake.

No code change.

## Changes

- `AGENTS.md`: add `### Container and bundle assets` under `Development guide` (+8 lines)

## Verification

Every statement was checked against the current code:

- `apps/cdk/lib/constructs/webapp.ts:74-76` and `apps/cdk/lib/constructs/async-job.ts:28-31` — both use `directory: join('..', '..')` with `ignoreMode: IgnoreMode.DOCKER`; root `.dockerignore` exists
- `apps/async-job/Dockerfile:8-10` — `pnpm install --frozen-lockfile` with no `--filter`
- `apps/async-job/Dockerfile:13,18` — `--format=esm --outfile=dist/handler.mjs`, and the runner copies `handler.mjs`
- `apps/async-job/Dockerfile:14` and `packages/db/package.json:28` — `--external:@aws-sdk/*` alongside the `@aws/aurora-dsql-node-postgres-connector` dependency

`pnpm -r run test:unit` ran via the pre-commit hook: 14 CDK tests passed. Docs-only change, so no deploy test.

## Checklist

- [x] I have read [`.starter-kit/DESIGN_PRINCIPLES.md`](https://github.com/aws-samples/serverless-full-stack-webapp-starter-kit/blob/main/.starter-kit/DESIGN_PRINCIPLES.md)
- [x] The diff is minimal
- [x] One-command deploy is preserved
- [x] The type-safety chain (Drizzle → Zod → Server Actions → React) is intact
- [x] Sample data uses fictitious values
- [x] Lint, build, and tests pass locally
